### PR TITLE
Remove image from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,5 @@
     <pre>
       helm repo add redhat-cop https://redhat-cop.github.io/helm-charts
     </pre>
-    <img src="https://i.pinimg.com/originals/c4/43/fc/c443fcf40abba3f9e098d5bd25ca20be.gif" alt="Pump It Up">
   </body>
 </html>


### PR DESCRIPTION
Removes unnecessary image from gh-pages. 

Resolves #78 

@redhat-cop/day-in-the-life @springdo 