### PR TITLE
🧪 ADD - Collection of charts used in UJ as docs for others to see 🏂

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# ⚓️ Open Innovation Labs Helm Charts
+# ⚓️ Red Hat Communities of Practice Helm Charts
 
 ![Release Charts](https://github.com/redhat-cop/helm-charts/workflows/Release%20Charts/badge.svg)
 
-A collection of Helm Charts to support [Labs Developer Experience](https://github.com/rht-labs/ubiquitous-journey)
+A collection of Helm Charts to that are not available in any upstream location or customised to the point it does not make sense to support up stream chart development.
+
+For charts we know work on OpenShift but do not belong here, check out the list of Charts we've used for some ideas
+
+This libary is used to support [Open Innovation Labs Ubiquitous Journey Project](https://github.com/rht-labs/ubiquitous-journey)
 
 ## 🧰 Add this Helm Repo to your local 🧰
 ```

--- a/charts-we-like.md
+++ b/charts-we-like.md
@@ -1,0 +1,67 @@
+## 🧰 OpenShift Ready Charts 🧰
+This collection of charts we've used in the past that runs on OpenShift. Here are some examples and the values used to run on OpenShift:
+
+#### 🗣 Mattermost
+![Mattermost](https://github.com/mattermost/mattermost-helm/tree/master/charts/mattermost-team-edition) is an OpenSource Chat Application. Example Values file for OpenShift:
+
+```yaml
+route:
+  enabled: true
+mysql:
+  mysqlRootPassword: "mysqlpass"
+  mysqlUser: "mattermost"
+  mysqlPassword: "matterpass"
+```
+
+#### 🧪 Zalenium
+![Zalenium](https://github.com/zalando/zalenium/tree/master/charts/zalenium) is a Selenium Grid deployment with on demand provisioning of the browsers for running your tests.
+
+```yaml
+hub:
+  serviceType: ClusterIP
+  openshift:
+    deploymentConfig:
+      enabled: true
+    route:
+      enabled: true
+  persistence:
+    enabled: false
+  serviceAccount:
+    create: false
+  desiredContainers: 0
+  podAnnotations:
+    app: zalenium
+```
+
+#### 🌮 Wekan
+[Wekan](https://github.com/wekan/wekan/tree/master/helm/wekan) is an OpenSource Kanban tool.
+
+```yaml
+service:
+  type: ClusterIP
+autoscaling:
+  enabled: false
+mongodb-replicaset:
+  replicas: 1
+  securityContext:
+    runAsUser: ""
+    fsGroup: ""
+ingress:
+  enabled: false
+route:
+  enabled: true
+```
+
+#### 🦟 Hoverfly
+![Hoverfly](https://github.com/helm/charts/tree/master/incubator/hoverfly) is a lightweight, open source API simulation tool. Using Hoverfly, you can create realistic simulations of the APIs your application depends on.
+```yaml
+replicaCount: "1"
+openshift:
+  route:
+    admin:
+      enabled: true
+      hostname: ""
+    proxy:
+      enabled: true
+      hostname: ""
+```


### PR DESCRIPTION
Starting point for adding how people can include charts they've used before but *not* the chart. Ie some upstream stuff.... 

@tylerauerbeck i know you're interested in this too 