### PR TITLE
🐪 switch to agent naming 🐪

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 0.0.19
+version: 0.0.20
 home: https://github.com/redhat-cop/helm-charts
 maintainers:
   - name: springdo

--- a/charts/jenkins/templates/imagestreams.yaml
+++ b/charts/jenkins/templates/imagestreams.yaml
@@ -4,7 +4,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   name: {{ .name }}
-  {{- if .name | regexFind ".*slave"  }}
+  {{- if or (.name | regexFind ".*slave") (.name | regexFind ".*agent")  }}
   labels:
     build: {{ .name }}
     role: jenkins-slave

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -89,19 +89,19 @@ imagestreams:
   #   builder_image: origin-jenkins
   #   builder_imagetag: latest
   # Jenkins agents image streams
-  - name: jenkins-slave-mvn
-  - name: jenkins-slave-argocd
-  - name: jenkins-slave-helm
-  - name: jenkins-slave-ansible
-  - name: jenkins-slave-arachni
-  - name: jenkins-slave-golang
-  - name: jenkins-slave-gradle
-  - name: jenkins-slave-image-mgmt
-  - name: jenkins-slave-mongodb
-  - name: jenkins-slave-npm
-  - name: jenkins-slave-python
-  - name: jenkins-slave-ruby
-  - name: jenkins-slave-conftest
+  - name: jenkins-agent-mvn
+  - name: jenkins-agent-argocd
+  - name: jenkins-agent-helm
+  - name: jenkins-agent-ansible
+  - name: jenkins-agent-arachni
+  - name: jenkins-agent-golang
+  - name: jenkins-agent-gradle
+  - name: jenkins-agent-image-mgmt
+  - name: jenkins-agent-mongodb
+  - name: jenkins-agent-npm
+  - name: jenkins-agent-python
+  - name: jenkins-agent-ruby
+  - name: jenkins-agent-conftest
 
 buildconfigs:
   # Jenkins S2I from Red Hat Labs
@@ -117,57 +117,57 @@ buildconfigs:
     builder_image_name: quay.io/openshift/origin-jenkins
     builder_image_tag: "latest"
   # Jenkins agents for running builds etc
-  - name: "jenkins-slave-mvn"
-    source_context_dir: "jenkins-slaves/jenkins-slave-mvn"
+  - name: "jenkins-agent-mvn"
+    source_context_dir: "jenkins-agents/jenkins-agent-mvn"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
+    source_repo_ref: "master"
     builder_image_name: "quay.io/eformat/origin-jenkins-agent-maven"
     builder_image_tag: "latest"
-  - name: "jenkins-slave-helm"
-    source_context_dir: "jenkins-slaves/jenkins-slave-helm"
+  - name: "jenkins-agent-helm"
+    source_context_dir: "jenkins-agents/jenkins-agent-helm"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-argocd"
-    source_context_dir: "jenkins-slaves/jenkins-slave-argocd"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-argocd"
+    source_context_dir: "jenkins-agents/jenkins-agent-argocd"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-arachni"
-    source_context_dir: "jenkins-slaves/jenkins-slave-arachni"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-arachni"
+    source_context_dir: "jenkins-agents/jenkins-agent-arachni"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-golang"
-    source_context_dir: "jenkins-slaves/jenkins-slave-golang"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-golang"
+    source_context_dir: "jenkins-agents/jenkins-agent-golang"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-gradle"
-    source_context_dir: "jenkins-slaves/jenkins-slave-gradle"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-gradle"
+    source_context_dir: "jenkins-agents/jenkins-agent-gradle"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-image-mgmt"
-    source_context_dir: "jenkins-slaves/jenkins-slave-image-mgmt"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-image-mgmt"
+    source_context_dir: "jenkins-agents/jenkins-agent-image-mgmt"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-mongodb"
-    source_context_dir: "jenkins-slaves/jenkins-slave-mongodb"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-mongodb"
+    source_context_dir: "jenkins-agents/jenkins-agent-mongodb"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-npm"
-    source_context_dir: "jenkins-slaves/jenkins-slave-npm"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-npm"
+    source_context_dir: "jenkins-agents/jenkins-agent-npm"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-python"
-    source_context_dir: "jenkins-slaves/jenkins-slave-python"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-python"
+    source_context_dir: "jenkins-agents/jenkins-agent-python"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-ruby"
-    source_context_dir: "jenkins-slaves/jenkins-slave-ruby"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-ruby"
+    source_context_dir: "jenkins-agents/jenkins-agent-ruby"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-ansible"
-    source_context_dir: "jenkins-slaves/jenkins-slave-ansible"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-ansible"
+    source_context_dir: "jenkins-agents/jenkins-agent-ansible"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
-  - name: "jenkins-slave-conftest"
-    source_context_dir: "jenkins-slaves/jenkins-slave-conftest"
+    source_repo_ref: "master"
+  - name: "jenkins-agent-conftest"
+    source_context_dir: "jenkins-agents/jenkins-agent-conftest"
     source_repo: "https://github.com/redhat-cop/containers-quickstarts"
-    source_repo_ref: "v1.26"
+    source_repo_ref: "master"


### PR DESCRIPTION
matches with master branch, jenkins agent rename. 

can switch to tagged version once stable upstream.