### PR TITLE
Fix ArgoCD initial repositories to point to correct location for charts

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.1
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 0.0.16
+version: 0.0.17
 home: https://github.com/redhat-cop/helm-charts
 maintainers:
 - name: springdo

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -44,9 +44,9 @@ server:
 initialRepositories:
   - name: ubiquitous-journey
     url: https://github.com/rht-labs/ubiquitous-journey.git
-  - name: rht-labs
+  - name: redhat-cop
     type: helm
-    url: https://rht-labs.github.io/helm-charts
+    url: https://redhat-cop.github.io/helm-charts
 
 secrets:
   - name: argocd-privaterepo


### PR DESCRIPTION
The initial repositories for the argo pointed at the old rht-labs.github.io/helm-charts which caused the [Ubiquitous Journey](https://github.com/rht-labs/ubiquitous-journey) to fail to deploy.

