### PR TITLE
Allows Operator to watch more than one NS and change the installMode

### DIFF
--- a/charts/operatorhub/Chart.yaml
+++ b/charts/operatorhub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operatorhub
 description: A Helm chart to create OperatorHub subscriptions
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.0.2
 home: https://github.com/redhat-cop/helm-charts
 maintainers:

--- a/charts/operatorhub/README.md
+++ b/charts/operatorhub/README.md
@@ -9,6 +9,9 @@ The OperatorHub and OLM are [available](https://docs.openshift.com/container-pla
 
 This chart enables specific operators as it creates a subscription for the specific operator. For this, it creates a Subscription resource instance and a OperatorGroup for the relevant operator's subscription. A ClusterServiceVersion (CSV) is created automatically since the value of CSV is set in the Subscription, so all of the custom resources relevant to the operator are created.
 
+If [installModes](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-membership_olm-understanding-operatorgroups) are specified, then the CSV object is patched accordingly.
+
+If the [namespaceSelector](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups) is set, then instead of targeting just the own Nnamespace, the operator will select multiple NS based on the label provided.
 
 ## Installing the chart
 
@@ -60,14 +63,40 @@ $ helm uninstall <name of chart>
 
 The following table lists the configurable parameters of the OperatorHub chart and their default values.
 
-| Parameter (For each `operator`)                             | Description                                                                  | Default                                        |
-| ------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------- |
-| `name`                        | Name of the Subscription                                                  |                                          |
-| `namespace`                        | The namespace the Subscription will be created in                                                 |                                        |
-| `subscription.channel`                        | Operator's subscription channel which is specific for the operator                                                 |                                        |
-| `subscription.approval`                        | Subscription's install plan approval                                                | `Automatic`                                          |
-| `subscription.operatorName`                        | Name of the operator                                                  |                                           |
-| `subscription.sourceName`                        | Operator's source which the operator belongs to                                                | `redhat-operators`                                          |
-| `subscription.sourceNamespace`                        | Operator's namespace where the operator will be pulled from                                                  | `openshift-marketplace`                                          |
-| `subscription.csv`                        | ClusterServiceVersion's name which will be created regarding to the operator                                                  |                                         |
-| `operatorgroup.create`                        | An OperatorGroup will be created with the same name of the Subscription if the value is `true`                                                  | `true`                                          |
+| Parameter (For each `operator`)                             | Description                                                               | Default                  |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------ |
+| `name`                                | Name of the Subscription                                                                        |                          |
+| `namespace`                           | The namespace the Subscription will be created in                                               |                          |
+| `subscription.channel`                | Operator's subscription channel which is specific for the operator                              |                          |
+| `subscription.approval`               | Subscription's install plan approval                                                            | `Automatic`              |
+| `subscription.operatorName`           | Name of the operator                                                                            |                          |
+| `subscription.sourceName`             | Operator's source which the operator belongs to                                                 | `redhat-operators`       |
+| `subscription.sourceNamespace`        | Operator's namespace where the operator will be pulled from                                     | `openshift-marketplace`  |
+| `subscription.csv`                    | ClusterServiceVersion's name which will be created regarding to the operator                    |                          |
+| `operatorgroup.create`                | An OperatorGroup will be created with the same name of the Subscription if the value is `true`  | `true`                   |
+| `operatorgroup.namespaceSelector`     | Optional. (It will be deprecated in futures releases). An OperatorGroup [namespace Selector](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups) in case your operator needs to watch more than one ns. Example: `"monitoring: yes"`.                                                                                                                                     |
+| `operatorgroup.installModes:`         | Optional. Change operator [install modes](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-membership_olm-understanding-operatorgroups) in the ClusterServiceVersion object.                                 |                          |
+
+Prometheus Operator example, with `namespaceSelector` and `installModes`:
+
+```yaml
+operators:
+  - name: prometheus-operator
+    namespace: prometheus-operator
+    subscription:
+      channel: beta
+      approval: Automatic
+      operatorName: prometheus
+      sourceName: community-operators
+      sourceNamespace: openshift-marketplace
+      csv: prometheusoperator.0.37.0
+    operatorgroup:
+      create: true
+      namespaceSelector: 'labelKey: LabelValue'
+    installModes:
+      OwnNamespace: true
+      SingleNamespace: false
+      MultiNamespace: true
+      AllNamespaces: false
+
+```

--- a/charts/operatorhub/templates/install-modes-post-hook.yaml
+++ b/charts/operatorhub/templates/install-modes-post-hook.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.operators }}
+{{- range $op := .Values.operators }}
+{{- if $op.installModes }}
+{{- $im := $op.installModes }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-csv
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: patch-csv
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: patch-csv
+subjects:
+- kind: ServiceAccount
+  name: patch-csv
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: patch-csv
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: operatorhub-{{ $op.name }}-{{ randAlphaNum 5 | lower }}-patch-csv
+  namespace: "{{ $op.namespace }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "operatorhub-{{ $op.name }}-install-modes-post-hook-job"
+    spec:
+      serviceAccount: patch-csv
+      serviceAccountName: patch-csv
+      restartPolicy: Never
+      containers:
+      - name: post-install-job
+        image: "quay.io/openshift/origin-cli:latest"
+        command:
+          - /bin/bash
+          - -c
+          - | #TODO: Get the CSV from the cluster instead from a var? 
+              oc -n {{ $op.namespace }} patch csv {{ $op.subscription.csv }} --type=merge -p '{"spec":{"installModes":[{"supported": {{ $im.OwnNamespace }}, "type":"OwnNamespace"},{"supported": {{ $im.SingleNamespace }}, "type":"SingleNamespace"},{"supported": {{ $im.MultiNamespace }}, "type":"MultiNamespace"},{"supported": {{ $im.AllNamespaces }}, "type":"AllNamespaces"}]}}'
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/operatorhub/templates/operatorgroup.yaml
+++ b/charts/operatorhub/templates/operatorgroup.yaml
@@ -10,8 +10,14 @@ metadata:
   name: {{ $op.name | quote }} 
   namespace: {{ $op.namespace | quote }}
 spec:
+  {{- if $og.namespaceSelector }}
+  selector:
+    matchLabels:
+      {{ $og.namespaceSelector }}
+  {{ else }}
   targetNamespaces:
   - {{ $op.namespace }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/operatorhub/templates/subscription.yaml
+++ b/charts/operatorhub/templates/subscription.yaml
@@ -14,7 +14,7 @@ spec:
   source: {{ $sub.sourceName | default "redhat-operators" | quote }}
   sourceNamespace: {{ $sub.sourceNamespace | default "openshift-marketplace" | quote }}
 {{- if $sub.csv }}
-  startingCSV: {{ $sub.csv }}
+  startingCSV: {{ $sub.csv | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Actually this PR does two things:

* Allows the Operator to [filter more than one NS with a label Selector](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups).
* Change the [installModes](https://docs.openshift.com/container-platform/4.5/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-membership_olm-understanding-operatorgroups) of the Operator. 

ping @ckavili @mvmaestri 