### PR TITLE
Fix to Nexus deploy naming

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -5,6 +5,6 @@ home: https://github.com/redhat-cop/helm-charts
 name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
-version: 0.0.5
+version: 0.0.6
 maintainers:
   - name: eformat

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -8,7 +8,7 @@ NEXUS_USER=admin:admin123
 NEXUS_URL=https://$(oc -n ${NS} get route nexus -o custom-columns=ROUTE:.spec.host --no-headers)
 
 echo "waiting for nexus pod ready..."
-oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=600s || exit $?
+oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=600s || exit $?
 sleep 2
 
 # helm hosted via rest
@@ -28,15 +28,15 @@ curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/npm/proxy" \
   -d "{ \"name\": \"labs-npm\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true}, \"proxy\": { \"remoteUrl\": \"https://registry.npmjs.org\", \"contentMaxAge\": 1440, \"metadataMaxAge\": 1440 }, \"httpClient\": { \"blocked\": false, \"autoBlock\": false, \"connection\": { \"retries\": 0, \"userAgentSuffix\": \"string\", \"timeout\": 60, \"enableCircularRedirects\": false, \"enableCookies\": false}}, \"negativeCache\": { \"enabled\": false, \"timeToLive\": 1440 } }"
 
 # disable anonymous access by not running onboarding
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if ! grep -q "nexus.onboarding.enabled" /nexus-data/etc/nexus.properties; then echo "nexus.onboarding.enabled=false" >> /nexus-data/etc/nexus.properties; fi'
+oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if ! grep -q "nexus.onboarding.enabled" /nexus-data/etc/nexus.properties; then echo "nexus.onboarding.enabled=false" >> /nexus-data/etc/nexus.properties; fi'
 
 # make groovy script api active
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if ! grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then echo "nexus.scripts.allowCreation=true" >> /nexus-data/etc/nexus.properties; fi'
+oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if ! grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then echo "nexus.scripts.allowCreation=true" >> /nexus-data/etc/nexus.properties; fi'
 
 # restart pod
 echo "restarting nexus..."
-oc -n ${NS} delete pod -lapp=sonatype-nexus
-oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=300s || exit $?
+oc -n ${NS} delete pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}"
+oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=300s || exit $?
 sleep 2
 
 # raw hosted not available on new beta rest api
@@ -51,12 +51,12 @@ curl -s -X POST "${NEXUS_URL}/service/rest/v1/script" \
 curl -s -X POST -u admin:admin123 --header "Content-Type: text/plain" "${NEXUS_URL}/service/rest/v1/script/labs-static/run" > /dev/null
 
 # disable groovy
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp=sonatype-nexus) -- bash -c 'if grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then sed -i -e "s|nexus.scripts.allowCreation=true|#nexus.scripts.allowCreation=true|g" /nexus-data/etc/nexus.properties; fi'
+oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then sed -i -e "s|nexus.scripts.allowCreation=true|#nexus.scripts.allowCreation=true|g" /nexus-data/etc/nexus.properties; fi'
 
 # restart
 echo "restarting nexus..."
-oc -n ${NS} delete pod -lapp=sonatype-nexus
-oc -n ${NS} wait pod -lapp=sonatype-nexus --for=condition=Ready --timeout=300s
+oc -n ${NS} delete pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}"
+oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=300s
 
 echo "Done!"
 {{- end}}


### PR DESCRIPTION
There was an issue with deploying the sonatype-nexus chart using `helm template redhat-cop/sonatype-nexus --version 0.0.5 --set=nameOverride=nexus --set=fullnameOverride=nexus | oc apply -f-` as the configure job which is run fails because the app label was incorrect. 

This PR variablises the app label to enable the configure job to work when the label is not `app: sonatype-nexus`.

The `nexus.name` variable doesn't seem to be picked up from the `_helpers.tpl` file so I've just used the same defaulting. If anyone with more helm knowledge knows any better way to do this I'll be happy to change.