### PR TITLE
🦅 bump default to argocd 1.8.1 🦅

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.1
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 0.0.19
+version: 0.0.20
 home: https://github.com/redhat-cop/helm-charts
 maintainers:
 - name: springdo

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -11,7 +11,7 @@ namespace: *ci_cd
 instancelabel: rht-labs.com/ubiquitous-journey
 
 # operator manages upgrades etc
-version: v1.7.7
+version: v1.8.1
 operator:
   version: argocd-operator.v0.0.14
   channel: alpha


### PR DESCRIPTION
bump to latest stable argocd 1.8.1 release
have tested this against UJ labs bootstrap - https://github.com/rht-labs/ubiquitous-journey/pull/201/files