### PR TITLE
add tls settings to sonarqube chart

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 0.0.9
+version: 0.0.10
 appVersion: "8.2-community"
 home: https://github.com/redhat-cop/helm-charts
 keywords:

--- a/charts/sonarqube/templates/sonar-route.yaml
+++ b/charts/sonarqube/templates/sonar-route.yaml
@@ -10,6 +10,9 @@ metadata:
     app: {{ .Values.appName }}
 spec:
   host: {{ .Values.route.host | quote }}
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
   port:
     targetPort: {{ .Values.route.targetPort | default "8080-tcp" }}
   to:


### PR DESCRIPTION
At present Sonarqube only has a route on http. This sets the route the same as other apps such as Jenkins which will by default be HTTPS. If needed I can also add a variable which allows you to toggle whether this is added though that doesn't seem to be present in other places in this repo