### PR TITLE
🦩 argocd - fix CRD race condition 🦩

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.8.2
+appVersion: v1.8.3
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.0.3
+version: 1.0.4
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.3
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/README.md
+++ b/charts/argocd-operator/README.md
@@ -14,12 +14,32 @@ The above command creates objects with default naming convention and configurati
 ## Removing
 
 To delete the chart:
-```
+```bash
 helm uninstall argocd --namespace labs-ci-cd
+```
+
+## Troubleshooting
+
+If your chart only partially installed you can try disabling hooks when deleting
+```bash
+helm delete argocd --no-hooks
 ```
 
 ## Configuration
 
 The [values.yml](values.yaml) file contains instructions for common chart overrides.
+
+If you wish to use ArgoCD to manage this chart directly (or as a helm chart dependency) you may need to make use of the `ignoreHelmHooks` flag to ignore helm lifecycle hooks. For example as a Helm Chart dependency to UJ bootstrap:
+```bash
+argocd app create bootstrap-journey \
+  --dest-namespace labs-bootstrap \
+  --dest-server https://kubernetes.default.svc \
+  --repo https://github.com/rht-labs/ubiquitous-journey.git \
+  --revision master \
+  --sync-policy automated \
+  --path "bootstrap" \
+  --helm-set argocd-operator.ignoreHelmHooks=true \
+  --values "values-bootstrap.yaml"
+```
 
 For more detailed overview of what's configurable, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/)

--- a/charts/argocd-operator/README.md
+++ b/charts/argocd-operator/README.md
@@ -4,19 +4,22 @@ ArgoCD Helm Chart customises and deploys the [ArgoCD](https://argoproj.github.io
 
 ## Installing the chart
 
-To install the chart:
-
+To install the chart from source:
 ```bash
-$ helm template -f argocd-operator/values.yaml argocd-operator | oc apply -f-
+helm upgrade --install argocd -f values.yaml . --create-namespace --namespace labs-ci-cd
 ```
 
-The above command creates objects with default naming convention and configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The above command creates objects with default naming convention and configuration.
+
+## Removing
+
+To delete the chart:
+```
+helm uninstall argocd --namespace labs-ci-cd
+```
 
 ## Configuration
-The following table lists the configurable parameters of the ArgoCD chart and their default values. For more detailed overview of what's configurable, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/)
 
-| Parameter                                        | Description                                                  | Default                               |
-| ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |
-| `namespace`                                      | Project name to deploy DevEx tools                           | `labs-ci-cd`                          |
-| `name`                                           | Project name for argocd server                               | `labs-argocd`                         |
-| `instancelabel`                                  | Unique identifier for argocd default label                   | `rht-labs.com/ubiquitous-journey`     |
+The [values.yml](values.yaml) file contains instructions for common chart overrides.
+
+For more detailed overview of what's configurable, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/)

--- a/charts/argocd-operator/templates/ArgoCD.yaml
+++ b/charts/argocd-operator/templates/ArgoCD.yaml
@@ -6,9 +6,11 @@ metadata:
   name: {{ .Values.name }}
   labels:
     app: {{ .Values.name }}
+  {{- if not .Values.ignoreHelmHooks }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
+  {{- end }}
   namespace: {{ .Values.namespace }}
 spec:
   applicationInstanceLabelKey: {{ .Values.instancelabel }}

--- a/charts/argocd-operator/templates/ArgoCD.yaml
+++ b/charts/argocd-operator/templates/ArgoCD.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ .Values.name }}
   labels:
     app: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
   namespace: {{ .Values.namespace }}
 spec:
   applicationInstanceLabelKey: {{ .Values.instancelabel }}

--- a/charts/argocd-operator/templates/crd-reader.yaml
+++ b/charts/argocd-operator/templates/crd-reader.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreHelmHooks }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -32,3 +33,4 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/argocd-operator/templates/crd-reader.yaml
+++ b/charts/argocd-operator/templates/crd-reader.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/argocd-operator/templates/crd-reader.yaml
+++ b/charts/argocd-operator/templates/crd-reader.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-reader
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - 'customresourcedefinitions'
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-reader-binding
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Values.namespace }}

--- a/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 rules:
   - apiGroups:
       - operators.coreos.com
@@ -32,7 +32,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -50,4 +50,4 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreHelmHooks }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -51,3 +52,4 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+{{- end }}

--- a/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook-rbac.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csv-deleter
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - delete
+      - list
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - argocds
+    verbs:
+      - delete
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csv-deleters
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csv-deleter
+subjects:
+  - kind: ServiceAccount
+    name: delete-csv-job
+    namespace: {{ .Values.namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-csv-job
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded

--- a/charts/argocd-operator/templates/delete-csv-hook.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-csv
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+        - image: quay.io/openshift/origin-cli:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              oc -n {{ .Values.namespace }} delete argocds.argoproj.io {{ .Values.name }} && \
+              oc -n {{ .Values.namespace }} delete $(oc get csv -l 'olm.copiedFrom notin (openshift-operators)' -o name)
+          imagePullPolicy: Always
+          name: installplan-approver
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: delete-csv-job
+      serviceAccountName: delete-csv-job
+      terminationGracePeriodSeconds: 10

--- a/charts/argocd-operator/templates/delete-csv-hook.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreHelmHooks }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -26,3 +27,4 @@ spec:
       serviceAccount: delete-csv-job
       serviceAccountName: delete-csv-job
       terminationGracePeriodSeconds: 10
+{{- end }}

--- a/charts/argocd-operator/templates/delete-csv-hook.yaml
+++ b/charts/argocd-operator/templates/delete-csv-hook.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   template:
     spec:

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -6,14 +6,14 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
   namespace: {{ .Values.namespace }}
 spec:
   containers:
   - name: crd-check 
     image: quay.io/openshift/origin-cli:4.6
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+    command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io applications.argoproj.io appprojects.argoproj.io argocdexports.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
   restartPolicy: Never
   terminationGracePeriodSeconds: 0
   serviceAccount: default

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ignoreHelmHooks }}
 ---
 apiVersion: v1
 kind: Pod
@@ -18,3 +19,4 @@ spec:
   terminationGracePeriodSeconds: 0
   serviceAccount: default
   serviceAccountName: default
+{{- end }}

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cluster-check 
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  namespace: {{ .Values.namespace }}
+spec:
+  containers:
+  - name: crd-check 
+    image: quay.io/openshift/origin-cli:4.6
+    imagePullPolicy: IfNotPresent
+    command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  serviceAccount: default
+  serviceAccountName: default

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -3,6 +3,9 @@
 enabled: true
 name: argocd
 
+# this is for argo type deployments (set to true) dont deploy helm hooked resources
+ignoreHelmHooks: false
+
 ci_cd_namespace: &ci_cd "labs-ci-cd"
 dev_namespace: &dev "labs-dev"
 test_namespace: &test "labs-test"

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -11,7 +11,7 @@ namespace: *ci_cd
 instancelabel: rht-labs.com/uj
 
 # operator manages upgrades etc
-version: v1.8.2
+version: v1.8.3
 operator:
   version: argocd-operator.v0.0.14
   channel: alpha


### PR DESCRIPTION
this fixes the race condition when installing argocd into an empty cluster using helm lifecycle hooks, waiting for CRD to be made available by subscription/OLM

the ramifications are that 'helm template' does not recognise these hooks, this will affect https://github.com/rht-labs/ubiquitous-journey usage e.g. bootstrap would look like this

```
# bootstrap to install argocd and create projects
helm upgrade --install bootstrap -f bootstrap/values-bootstrap.yaml bootstrap --create-namespace --namespace labs-bootstrap
# uninstall bootstrap chart
helm delete bootstrap --namespace labs-bootstrap --debug
```