### PR TITLE
🦤 tidy up hook deletion on failure 🦤

### DIFF
--- a/charts/ploigos/Chart.yaml
+++ b/charts/ploigos/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ploigos
 description: A Helm chart for Ploigos - Trusted Software Supply Chain
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.2.2
 home: https://github.com/redhat-cop/helm-charts
 maintainers:

--- a/charts/ploigos/templates/crd-reader.yaml
+++ b/charts/ploigos/templates/crd-reader.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/ploigos/templates/delete-csv-hook-rbac.yaml
+++ b/charts/ploigos/templates/delete-csv-hook-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 rules:
   - apiGroups:
       - operators.coreos.com
@@ -23,7 +23,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -39,4 +39,4 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed

--- a/charts/ploigos/templates/delete-csv-hook.yaml
+++ b/charts/ploigos/templates/delete-csv-hook.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   template:
     spec:

--- a/charts/ploigos/templates/wait-for-crd.yaml
+++ b/charts/ploigos/templates/wait-for-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   containers:
   - name: crd-check 


### PR DESCRIPTION
add hook-failed to deletion so resources removed on failure
help with a rerun
also worth noting the '--no-hooks' cli switch can be handy sometimes:
```
helm uninstall ploigos --no-hooks
```