### PR TITLE
Create static repo through beta rest api and make repo names from vars

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -6,6 +6,6 @@ name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: eformat

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -1,4 +1,4 @@
-## sonatype-nexus
+# sonatype-nexus
 
 Chart was forked from the official sonatype nexus operator (which actually calls this chart). It uses a UBI based image set in [values.yaml](values.yaml)
 
@@ -8,13 +8,17 @@ Chart was forked from the official sonatype nexus operator (which actually calls
 
 https://github.com/sonatype/operator-nxrm3/blob/master/helm-charts/sonatype-nexus/Chart.yaml
 
-Features:
+## Features
+
 - nexus default admin password used
 - services and route setup for openshift
-- anonymouns access on by default, initial configuration turned off
+- anonymous access on by default, initial configuration turned off
 - post setup k8s job to configure repositories [setup-nexus-job.yaml](templates/setup-nexus-job.yaml) suitable for labs-ci-cd in UJ (raw, helm, npm etc)
 
-Run:
+## Installing the chart
+
+To install the chart:
+
 ```bash
 oc new-project nexus-test
 helm template my -f sonatype-nexus/values.yaml sonatype-nexus/ | oc apply -f-
@@ -24,19 +28,16 @@ Check success of setup job:
 ```bash
 $ stern nexus-setup-p4ddg
 
-+ nexus-setup-p4ddg › nc
-nexus-setup-p4ddg nc waiting for nexus pod ready...
-nexus-setup-p4ddg nc pod/my-sonatype-nexus-58f49d48d9-2vhbz condition met
-nexus-setup-p4ddg nc creating helm-charts helm hosted repo
-nexus-setup-p4ddg nc creating labs-npm npm proxy
-nexus-setup-p4ddg nc restarting nexus...
-nexus-setup-p4ddg nc pod "my-sonatype-nexus-58f49d48d9-2vhbz" deleted
-nexus-setup-p4ddg nc pod/my-sonatype-nexus-58f49d48d9-54mn8 condition met
-nexus-setup-p4ddg nc creating labs-static raw hosted repo
-nexus-setup-p4ddg nc restarting nexus...
-nexus-setup-p4ddg nc pod "my-sonatype-nexus-58f49d48d9-54mn8" deleted
-nexus-setup-p4ddg nc pod/my-sonatype-nexus-58f49d48d9-n9z8x condition met
-nexus-setup-p4ddg nc Done!
++ nexus-setup-26nqt › nc
+nexus-setup-26nqt nc waiting for nexus pod ready...
+nexus-setup-26nqt nc pod/nexus-sonatype-nexus-7b8b68955c-48jbx condition met
+nexus-setup-26nqt nc creating helm-charts helm hosted repo
+nexus-setup-26nqt nc creating labs-npm npm proxy
+nexus-setup-26nqt nc creating labs-static raw hosted repo
+nexus-setup-26nqt nc restarting nexus...
+nexus-setup-26nqt nc pod "nexus-sonatype-nexus-7b8b68955c-48jbx" deleted
+nexus-setup-26nqt nc pod/nexus-sonatype-nexus-7b8b68955c-6sr4x condition met
+nexus-setup-26nqt nc Done!
 ```
 
 Delete the `nexus-setup` job resources (only needed to run once)
@@ -44,3 +45,13 @@ Delete the `nexus-setup` job resources (only needed to run once)
 oc delete job,sa -lapp=nexus-setup
 oc delete rolebinding edit-0
 ```
+
+## Configuration
+The following table lists the most common configurable parameters for the Nexus application, along with their default values. For a full listing of values which may want to be configured see the [values.yaml](values.yaml) file.
+
+| Parameter                                        | Description                                                  | Default                               |
+| ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |
+| `helmRepository`                                 | Name of the hosted Helm repository                           | `helm-charts`                         |
+| `npmRepository`                                  | Name of the NPM proxy repository                             | `labs-npm`                            |
+| `rawRepository`                                  | Name of the hosted raw repository                            | `labs-static`                         |
+| `persistence.storageSize`                        | Size of the generated PVC for Nexus                          | `8Gi`                                 |

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -20,40 +20,24 @@ curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/helm/hosted" \
   -d "{ \"name\": \"{{ .Values.helmRepository | default "helm-charts" }}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true, \"writePolicy\": \"ALLOW\" }}"
 
 # npm proxy
-echo "creating labs-npm npm proxy"
+echo "creating {{ .Values.npmRepository | default "labs-npm" }} npm proxy"
 curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/npm/proxy" \
   --user "${NEXUS_USER}" \
   -H "accept: application/json" \
   -H "Content-Type: application/json" \
-  -d "{ \"name\": \"labs-npm\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true}, \"proxy\": { \"remoteUrl\": \"https://registry.npmjs.org\", \"contentMaxAge\": 1440, \"metadataMaxAge\": 1440 }, \"httpClient\": { \"blocked\": false, \"autoBlock\": false, \"connection\": { \"retries\": 0, \"userAgentSuffix\": \"string\", \"timeout\": 60, \"enableCircularRedirects\": false, \"enableCookies\": false}}, \"negativeCache\": { \"enabled\": false, \"timeToLive\": 1440 } }"
+  -d "{ \"name\": \"{{ .Values.npmRepository | default "labs-npm" }}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true}, \"proxy\": { \"remoteUrl\": \"https://registry.npmjs.org\", \"contentMaxAge\": 1440, \"metadataMaxAge\": 1440 }, \"httpClient\": { \"blocked\": false, \"autoBlock\": false, \"connection\": { \"retries\": 0, \"userAgentSuffix\": \"string\", \"timeout\": 60, \"enableCircularRedirects\": false, \"enableCookies\": false}}, \"negativeCache\": { \"enabled\": false, \"timeToLive\": 1440 } }"
+
+# raw hosted via rest
+echo "creating {{ .Values.rawRepository | default "labs-static" }} raw hosted repo"
+curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/raw/hosted" \
+  --user "${NEXUS_USER}" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d "{ \"name\": \"{{ .Values.rawRepository | default "labs-static" }}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true, \"writePolicy\": \"ALLOW\" }}"
 
 # disable anonymous access by not running onboarding
 oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if ! grep -q "nexus.onboarding.enabled" /nexus-data/etc/nexus.properties; then echo "nexus.onboarding.enabled=false" >> /nexus-data/etc/nexus.properties; fi'
 
-# make groovy script api active
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if ! grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then echo "nexus.scripts.allowCreation=true" >> /nexus-data/etc/nexus.properties; fi'
-
-# restart pod
-echo "restarting nexus..."
-oc -n ${NS} delete pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}"
-oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=300s || exit $?
-sleep 2
-
-# raw hosted not available on new beta rest api
-echo "creating labs-static raw hosted repo"
-curl -s -X POST "${NEXUS_URL}/service/rest/v1/script" \
-     --user "admin:admin123" \
-     -H "accept: application/json" \
-     -H "Content-Type: application/json" \
-     -d "{ \"name\": \"labs-static\", \"content\": \"repository.createRawHosted('labs-static', 'default')\", \"type\": \"groovy\"}"
-
-# start repo up
-curl -s -X POST -u admin:admin123 --header "Content-Type: text/plain" "${NEXUS_URL}/service/rest/v1/script/labs-static/run" > /dev/null
-
-# disable groovy
-oc -n ${NS} exec $(oc -n ${NS} get pods -o custom-columns=NAME:.metadata.name --no-headers -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}") -- bash -c 'if grep -q "^nexus.scripts.allowCreation" /nexus-data/etc/nexus.properties; then sed -i -e "s|nexus.scripts.allowCreation=true|#nexus.scripts.allowCreation=true|g" /nexus-data/etc/nexus.properties; fi'
-
-# restart
 echo "restarting nexus..."
 oc -n ${NS} delete pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}"
 oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=300s


### PR DESCRIPTION
I needed to be able to change the names of the repos created in the setup script ad was also finding the raw repo wasn't being generated. I'm assuming this is because the old way is now outdated. I've used the beta rest API to create the raw hosted repo and this seems to work fine now. 

Also added the ability to define the repo names in vars `npmRepository` and `rawRepository` to match `helmRepository`. The default names for these repos match what was used before so there should be no breaking changes.