### PR TITLE
Ability to add labels to namespaces

### DIFF
--- a/charts/bootstrap-project/Chart.yaml
+++ b/charts/bootstrap-project/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.0.1"
 description: A Helm chart for deploying and managing Openshift projects 🦆
 name: bootstrap-project
-version: 0.0.8
+version: 0.0.9
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.iconpacks.net/icons/1/free-rocket-icon-1206-thumb.png
 maintainers:

--- a/charts/bootstrap-project/README.md
+++ b/charts/bootstrap-project/README.md
@@ -17,9 +17,9 @@ The following table lists the configurable parameters of the Bootstrap chart and
 
 | Parameter                                        | Description                                                  | Default                               |
 | ------------------------------------------------ | -------------------------------------------------------------| ------------------------------------- |
-| `ci_cd_namespace`                                | Project name to deploy DevEx tools                           | `labs-ci-cd`                               |
-| `dev_namespace`                                  | Project name for dev environment                             | `labs-dev`                                 |
-| `test_namespace`                                 | Project name for test environment                            | `labs-test`                                |
+| `ci_cd_namespace`                                | Project name to deploy DevEx tools                           | `labs-ci-cd`                          |
+| `dev_namespace`                                  | Project name for dev environment                             | `labs-dev`                            |
+| `test_namespace`                                 | Project name for test environment                            | `labs-test`                           |
 | `namespaces.labs-ci-cd.bindings.name`            | IDM group name to assign role in ci-cd namespace             | `[labs-devs, labs-admins, dummy-sa]`  |
 | `namespaces.labs-ci-cd.bindings.kind`            | Kind to bind to the role in ci-cd namespace                  | `[Group, ServiceAccount]`             |
 | `namespaces.labs-ci-cd.bindings.role`            | The role to bind to the group in ci-cd namespace             | `[edit, admin]`                       |
@@ -29,6 +29,7 @@ The following table lists the configurable parameters of the Bootstrap chart and
 | `namespaces.labs-test.bindings.name`             | IDM group name to assign role in test namespace              | `[labs-devs, labs-admins, dummy-sa]`  |
 | `namespaces.labs-test.bindings.kind`             | Kind to bind to the role in test namespace                   | `[Group, ServiceAccount]`             |
 | `namespaces.labs-test.bindings.role`             | The role to bind to the group in test namespace              | `[edit, admin]`                       |
+| `namespaces.[*].labels`                          | The labels applied to the namespace                          | {}                                    |
 | `serviceaccounts.name`                           | The name of the service account that will be created         | `dummy-sa`                            |
 | `serviceaccounts.namespace`                      | The namespace that the service account will be created in    | `dummy-sa`                            |
 

--- a/charts/bootstrap-project/templates/namespace.yaml
+++ b/charts/bootstrap-project/templates/namespace.yaml
@@ -6,5 +6,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $ns | quote}}
+  {{- if $key.labels }}
+  labels:
+  {{- range $k,$v := $key.labels }}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This enables adding labels to namespaces.

Only makes a change to current charts outputs if the `namespaces.*.labels` value is set.