### PR TITLE
🍩 cleanup mvn, graal agent images 🍩

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 0.0.23
+version: 0.0.24
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -151,8 +151,6 @@ buildconfigs:
     source_context_dir: "jenkins-agents/jenkins-agent-graalvm"
     source_repo: *jarepo
     source_repo_ref: "master"
-    builder_image_name: "quay.io/openshift/origin-jenkins-agent-maven"
-    builder_image_tag: "4.5"
   - name: "jenkins-agent-gradle"
     source_context_dir: "jenkins-agents/jenkins-agent-gradle"
     source_repo: *jarepo
@@ -173,8 +171,6 @@ buildconfigs:
     source_context_dir: "jenkins-agents/jenkins-agent-mvn"
     source_repo: *jarepo
     source_repo_ref: "master"
-    builder_image_name: "quay.io/eformat/origin-jenkins-agent-maven"
-    builder_image_tag: "latest"
   - name: "jenkins-agent-npm"
     source_context_dir: "jenkins-agents/jenkins-agent-npm"
     source_repo: *jarepo


### PR DESCRIPTION
since we now have a much cleaner graal/mandrel java image introduced here - https://github.com/redhat-cop/containers-quickstarts/pull/437
we can now put back the default mvn and graal agent images in the jenkins chart
the previous mvn agent build was put in place, whilst ubi and mvn3.6+ shuffle upstream merged
 
