### PR TITLE
added eap example to charts-we-like

### DIFF
--- a/charts-we-like.md
+++ b/charts-we-like.md
@@ -118,3 +118,26 @@ server:
         path = "/vault/data"
       }
 ```
+
+### 🚉 EAP
+[EAP](https://github.com/jbossas/eap-charts.git) 
+is Red Hat's [Jakarta EE offering](https://www.redhat.com/en/technologies/jboss-middleware/application-platform)
+
+```yaml
+build:
+  uri: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+  ref: EAP_7.4.0.Beta
+  pullSecret: replace-with-your-secret
+  s2i:
+    jdk: "11"
+    galleonLayers: 'jaxrs-server'
+  env:
+  - name: ARTIFACT_DIR
+    value: helloworld-rs/target
+  - name: MAVEN_ARGS_APPEND
+    value: -am -pl helloworld-rs
+  - name: MAVEN_OPTS
+    value: '-XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m'
+deploy:
+  replicas: 3
+```


### PR DESCRIPTION
#### What is this PR About?
in the process of migrating the containers-quickstarts/eap chart over to here, i found that the engineers have created one, so have doc'ed that instead in the charts-we-like, instead of pulling in the chart
- https://github.com/redhat-cop/containers-quickstarts/issues/472

cc: @redhat-cop/day-in-the-life
