### PR TITLE
🥝 support a list of helm chart repos 🥝

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -6,6 +6,6 @@ name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
-version: 0.0.12
+version: 0.0.13
 maintainers:
   - name: eformat

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -13,11 +13,15 @@ sleep 2
 
 # helm hosted via rest
 echo "creating {{ .Values.helmRepository | default "helm-charts" }} helm hosted repo"
-curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/helm/hosted" \
-  --user "${NEXUS_USER}" \
-  -H "accept: application/json" \
-  -H "Content-Type: application/json" \
-  -d "{ \"name\": \"{{ .Values.helmRepository | default "helm-charts" }}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true, \"writePolicy\": \"ALLOW\" }}"
+helmList='{{ .Values.helmRepository | default "helm-charts" }}'
+helmList=`echo "$helmList" | sed -r 's/\[|\]//g'`
+for repo in ${helmList}; do
+    curl -s -k -X POST "${NEXUS_URL}/service/rest/beta/repositories/helm/hosted" \
+    --user "${NEXUS_USER}" \
+    -H "accept: application/json" \
+    -H "Content-Type: application/json" \
+    -d "{ \"name\": \"${repo}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true, \"writePolicy\": \"ALLOW\" }}"
+done
 
 # npm proxy
 echo "creating {{ .Values.npmRepository | default "labs-npm" }} npm proxy"

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -22,6 +22,12 @@ ingress:
   tls:
     enabled: true
     secretName: nexus-tls
+
+helmRepository:
+  - helm-charts
+  - helm-charts-stable
+  - helm-charts-incubator
+
 nexus:
   dockerPort: 5003
   env:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -22,12 +22,10 @@ ingress:
   tls:
     enabled: true
     secretName: nexus-tls
-
 helmRepository:
   - helm-charts
   - helm-charts-stable
   - helm-charts-incubator
-
 nexus:
   dockerPort: 5003
   env:


### PR DESCRIPTION
#### What is this PR About?
Support a List of helm chart repos to create.

This is similar to -stable and -incubator repos in the docs:
https://helm.sh/blog/new-location-stable-incubator-charts

and supports common use cases for deploying charts to different nexus helm chart repos (-dev, -test, -staging)

#### How do we test this?
Tested using helm template into new namespace
```
helm template foo . | oc apply -f-
```

cc: @redhat-cop/day-in-the-life
