### PR TITLE
Update chart-releaser action version and workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,21 +11,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      # See https://github.com/helm/chart-releaser-action/issues/6
       - name: Install Helm
-        run: |
-          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.3
 
       - name: Add dependency chart repos
         run: |
@@ -33,6 +30,6 @@ jobs:
           helm repo add incubator https://charts.helm.sh/incubator
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        uses: helm/chart-releaser-action@v1.2.0
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.3
+          version: latest 
 
       - name: Add dependency chart repos
         run: |


### PR DESCRIPTION
#### What is this PR About?
This PR updates the chart release workflow to use the up-to-date version of the chart-releaser action (and now uses a `setup-helm` action to allow us to specify a version of helm vs just using the latest)

#### How do we test this?

You can see the results of the PR working in my branch here: https://github.com/tylerauerbeck/charts-3/runs/2328830798?check_suite_focus=true


cc: @redhat-cop/day-in-the-life
