### PR TITLE
Add kopf crd chart

### DIFF
--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -184,3 +184,14 @@ setup_file() {
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 0 ]
 }
+
+@test "charts/kopf" {
+  tmp=$(helm_template "charts/tekton-demo")
+
+  namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
+  cmd="conftest test ${tmp} --output tap ${namespaces}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 0 ]
+}

--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -186,7 +186,7 @@ setup_file() {
 }
 
 @test "charts/kopf" {
-  tmp=$(helm_template "charts/tekton-demo")
+  tmp=$(helm_template "charts/kopf")
 
   namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
   cmd="conftest test ${tmp} --output tap ${namespaces}"

--- a/charts/kopf/.helmignore
+++ b/charts/kopf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kopf/.test.sh
+++ b/charts/kopf/.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+trap "exit 1" TERM
+export TOP_PID=$$
+
+export project_name="kopf-$(date +'%d%m%Y')"
+
+install() {
+  echo "install - $(pwd)"
+
+  oc new-project ${project_name}
+  helm install kopf kopf
+}
+
+test() {
+  echo "test - $(pwd)"
+
+
+  for i in clusterkopfpeerings.kopf.dev kopfpeerings.kopf.dev; do
+	  oc get crd $i
+	  if [[ $? != 0 ]]; then
+		  echo "CRD: $i not present"
+		  exit 1
+	 fi
+  done
+
+  echo "Test complete"
+}
+
+cleanup() {
+  echo "cleanup - $(pwd)"
+  helm uninstall kopf
+  oc delete project/${project_name}
+}
+
+# Process arguments
+case $1 in
+  install)
+    install
+    ;;
+  test)
+    test
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  *)
+    echo "Not an option"
+    exit 1
+esac

--- a/charts/kopf/.test.sh
+++ b/charts/kopf/.test.sh
@@ -9,7 +9,7 @@ install() {
   echo "install - $(pwd)"
 
   oc new-project ${project_name}
-  helm install kopf kopf
+  helm install kopf .
 }
 
 test() {

--- a/charts/kopf/Chart.yaml
+++ b/charts/kopf/Chart.yaml
@@ -1,24 +1,10 @@
 apiVersion: v2
 name: kopf
 description: A Helm chart to deploy CustomResourceDefinitions required for the Kopf framework 
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application 
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "1.29.2"
+home: https://github.com/redhat-cop/helm-charts
+maintainers:
+- name: tylerauerbeck 
+- name: jkupferer 

--- a/charts/kopf/Chart.yaml
+++ b/charts/kopf/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: kopf
-description: A Helm chart to deploy CustomResourceDefinitions required for the Kopf framework 
-type: application 
+description: A Helm chart to deploy CustomResourceDefinitions required for the Kopf framework
+type: application
 version: 0.1.0
 appVersion: "1.29.2"
 home: https://github.com/redhat-cop/helm-charts
 maintainers:
-- name: tylerauerbeck 
-- name: jkupferer 
+- name: tylerauerbeck
+- name: jkupferer

--- a/charts/kopf/Chart.yaml
+++ b/charts/kopf/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kopf
+description: A Helm chart to deploy CustomResourceDefinitions required for the Kopf framework 
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application 
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.30.3"

--- a/charts/kopf/Chart.yaml
+++ b/charts/kopf/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.30.3"
+appVersion: "1.29.2"

--- a/charts/kopf/templates/clusterkopfpeering.yaml
+++ b/charts/kopf/templates/clusterkopfpeering.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.clusterkopf -}}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterkopfpeerings.kopf.dev
+spec:
+  scope: Cluster
+  group: kopf.dev
+  names:
+    kind: ClusterKopfPeering
+    plural: clusterkopfpeerings
+    singular: clusterkopfpeering
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+{{- end -}}

--- a/charts/kopf/templates/kopfpeering.yaml
+++ b/charts/kopf/templates/kopfpeering.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.kopf -}}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kopfpeerings.kopf.dev
+spec:
+  scope: Namespaced
+  group: kopf.dev
+  names:
+    kind: KopfPeering
+    plural: kopfpeerings
+    singular: kopfpeering
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+{{- end -}}

--- a/charts/kopf/values.yaml
+++ b/charts/kopf/values.yaml
@@ -1,4 +1,3 @@
-
-
-kopf: true 
+---
+kopf: true
 clusterkopf: true

--- a/charts/kopf/values.yaml
+++ b/charts/kopf/values.yaml
@@ -1,0 +1,4 @@
+
+
+kopf: true 
+clusterkopf: true


### PR DESCRIPTION
#### What is this PR About?
This adds a chart that deploys the CRDs for https://github.com/nolar/kopf . It provides the ability to deploy both or only one of kopfpeering/clusterkopfpeering depending on your need.

#### How do we test this?
`helm template .` 

cc: @redhat-cop/day-in-the-life @jkupferer 
