### PR TITLE
🐐 ADD - new approach to ArgoCD CR values 🐐

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.7
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.0.6
+version: 1.1.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/README.md
+++ b/charts/argocd-operator/README.md
@@ -29,6 +29,8 @@ helm delete argocd --no-hooks
 
 The [values.yml](values.yaml) file contains instructions for common chart overrides.
 
+Anything configurable in the Operator is passed to the ArgoCD custom resource provided by the Operator. For more detailed overview of what's included, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/)
+
 If you wish to use ArgoCD to manage this chart directly (or as a helm chart dependency) you may need to make use of the `ignoreHelmHooks` flag to ignore helm lifecycle hooks. For example as a Helm Chart dependency to UJ bootstrap:
 ```bash
 argocd app create bootstrap-journey \
@@ -41,5 +43,3 @@ argocd app create bootstrap-journey \
   --helm-set argocd-operator.ignoreHelmHooks=true \
   --values "values-bootstrap.yaml"
 ```
-
-For more detailed overview of what's configurable, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/)

--- a/charts/argocd-operator/templates/ArgoCD.yaml
+++ b/charts/argocd-operator/templates/ArgoCD.yaml
@@ -13,57 +13,13 @@ metadata:
   {{- end }}
   namespace: {{ .Values.namespace }}
 spec:
-  applicationInstanceLabelKey: {{ .Values.instancelabel }}
-  {{- if .Values.accounts }}  
-  {{- .Values.accounts | toYaml | trim | nindent 2 }}
-  {{- end }}   
-  dex:
-    openShiftOAuth: true
-  ha:
-    enabled: {{ .Values.ha.enabled }}
-  grafana:
-{{- if .Values.metrics.enabled }}  
-    enabled: true
-{{- else }}
-    enabled: false
-{{- end }}
-    route:
-      enabled: true
-    size: 1
-  prometheus:
-{{- if .Values.metrics.enabled }}  
-    enabled: true
-{{- else }}
-    enabled: false
-{{- end }}
-    route:
-      enabled: true
-    size: 1
-  {{- with .Values.rbac }}
-  rbac:
-    {{- . | toYaml | trim | nindent 4 }}
-  {{- end }}
-  {{- with .Values.initialRepositories }}
-  initialRepositories: |
-   {{- . | toYaml | trim | nindent 4 }}
-  {{- end }}
-  {{- with .Values.repositoryCredentials }}
-  repositoryCredentials: |
-   {{- . | toYaml | trim | nindent 4 }}
-  {{- end }}
-  {{- if .Values.initialSSHKnownHosts }}
-  initialSSHKnownHosts: 
-    keys: |
-      {{- range $host := .Values.initialSSHKnownHosts }}
-      {{ $host }}
-      {{- end }}
-  {{- end }}
+  # some defaults 🤷‍♂️
   insecure: false
-  {{- with .Values.server }}
-  server:
-    {{- . | toYaml | trim | nindent 4 }}
-  {{- end }} 
   statusBadgeEnabled: true
   usersAnonymousEnabled: false
-  version: {{ .Values.version | quote }}
+  dex:
+    openShiftOAuth: true
+  {{- if .Values.argocd_cr }}
+  {{- .Values.argocd_cr | toYaml | trim | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/argocd-operator/templates/Secret.yaml
+++ b/charts/argocd-operator/templates/Secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/part-of: argocd

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -6,12 +6,7 @@ name: argocd
 # this is for argo type deployments (set to true) dont deploy helm hooked resources
 ignoreHelmHooks: false
 
-ci_cd_namespace: &ci_cd "labs-ci-cd"
-dev_namespace: &dev "labs-dev"
-test_namespace: &test "labs-test"
-
-namespace: *ci_cd
-instancelabel: rht-labs.com/uj
+namespace: labs-ci-cd
 
 # operator manages upgrades etc
 version: v1.8.7
@@ -21,63 +16,79 @@ operator:
   name: argocd-operator
   operatorgroup: true
 
-# https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
+# role bindings, enable this to restrict to listed namespaces only. cluster role by default (enabled: false)
+namespaceRoleBinding:
+  enabled: false
+  namespaces:
+    - name: labs-ci-cd
+    - name: labs-dev"
+    - name: labs-test"
+    - name: labs-staging"
+
+# if using metrics, handy to deploy an instance of prometheus
 metrics:
   enabled: false
   prometheus:
     version: prometheusoperator.0.37.0
     channel: beta
     name: prometheus-operator
-ha:
-  enabled: false
 
-rbac:
-  defaultPolicy: role:admin
+# https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
+argocd_cr:
+  applicationInstanceLabelKey: rht-labs.com/uj123
 
-server:
-  route:
+  grafana:
     enabled: true
-  autoscale:
+    route:
+      enabled: true
+    size: 1
+  prometheus:
+    enabled: true
+    route:
+      enabled: true
+    size: 1
+  ha:
     enabled: false
-  service:
-    type: ClusterIP
 
-# See here for private repos
-# https://argocd-operator.readthedocs.io/en/v0.0.8/reference/argocd/#initial-repositories-example
-initialRepositories:
-  - name: ubiquitous-journey
-    url: https://github.com/rht-labs/ubiquitous-journey.git
-  - name: redhat-cop
-    type: helm
-    url: https://redhat-cop.github.io/helm-charts
+  rbac:
+    defaultPolicy: role:admin
 
-# configure your repo credential template
-# example for ref only
-repositoryCredentials:
-  - url: https://gitlab-ce.apps.example.cluster.com
-    type: git
-    passwordSecret:
-      key: password
-      name: argocd-privaterepo
-    usernameSecret:
-      key: username
-      name: argocd-privaterepo
-secrets:
-  - name: argocd-privaterepo
-    username: "user123"
-    password: "pass123"
-    sshPrivateKey: ""
+  server:
+    route:
+      enabled: true
+    autoscale:
+      enabled: false
+    service:
+      type: ClusterIP
 
-# examples
-accounts:
-  accounts.admin: login, apiKey
-  accounts.alice: apiKey
-  accounts.alice.enabled: "false"
+  # See here for private repos
+  # https://argocd-operator.readthedocs.io/en/v0.0.8/reference/argocd/#initial-repositories-example
+  initialRepositories: |
+    - name: ubiquitous-journey
+      url: https://github.com/rht-labs/ubiquitous-journey.git
+    - name: redhat-cop
+      type: helm
+      url: https://redhat-cop.github.io/helm-charts
 
-# role bindings, enable this to restrict to listed namespaces only. cluster role by default (enabled: false)
-namespaceRoleBinding:
-  enabled: false
-  namespaces:
-  - name: *ci_cd
-  - name: *dev
-  - name: *test
+  # configure your repo credential template
+  # example for ref only
+  repositoryCredentials: |
+    - url: https://gitlab-ce.apps.example.cluster.com
+      type: git
+      passwordSecret:
+        key: password
+        name: argocd-privaterepo
+      usernameSecret:
+        key: username
+        name: argocd-privaterepo
+  secrets:
+    - name: argocd-privaterepo
+      username: 'user123'
+      password: 'pass123'
+      sshPrivateKey: ''
+
+  # examples
+  accounts:
+    accounts.admin: login, apiKey
+    accounts.alice: apiKey
+    accounts.alice.enabled: 'false'


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR
This PR is to rewrite how we are passing values to the ArgoCD custom resource used to configure an instance of the server. At the moment, our helm chart is very inflexible and requires the template to be written such that it accepts things we want to configure. Im proposing we just take anything specified in the values file under the `argocd_cr`  property and apply it to teh `ArgoCD` CR spec. This will future proof the helm chart so when new features arrive in the operator, we're not back porting them to our template of the `ArgoCD` CR

This is a breaking change so would be good to get some input from @eformat @ckavili and anyone else who uses this chart as much as we do. 

#### How do we test this?
Provide commands/steps to test this PR.

`helm install my -f values.yaml . --dry-run --set namespace=ds-test123`


cc: @redhat-cop/day-in-the-life
