### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -1,6 +1,8 @@
 name: Validate
 
 on: [push, pull_request]
+  paths-ignore:
+    - '.github/**'
 
 jobs:
   conftest:

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -1,8 +1,12 @@
 name: Validate
 
-on: [push, pull_request]
-  paths-ignore:
-    - '.github/**'
+on: 
+  push:
+    paths-ignore:
+      - '.github/**'
+  pull_request:
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   conftest:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,8 +1,9 @@
 name: Lint and Test Charts
 
-on: pull_request
-  paths-ignore:
-    - '.github/**'
+on: 
+  pull_request:
+    paths-ignore:
+      - '.github/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,7 +1,8 @@
 name: Lint and Test Charts
 
 on: pull_request
-
+  paths-ignore:
+    - '.github/**'
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   release:


### PR DESCRIPTION
#### What is this PR About?
This PR configures Dependabot to also watch GH Actions and allows it to open a PR if we're using old versions of Actions. It also tells existing actions to ignore a PR if things under the .github directory are changed. Some tuning may be required here, but we likely don't want all of our workflows triggering if we're just making changes to a workflow. 

#### How do we test this?
Nothing to test. After merge, this will begin to watch the repo for out of date actions. This can be seen here: tylerauerbeck/charts-3#1




Provide commands/steps to test this PR.

cc: @redhat-cop/day-in-the-life
