### PR TITLE
🪅 fix cr version broken in  #150 🪅

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.8.7
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.1
+version: 1.1.2
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -9,7 +9,6 @@ ignoreHelmHooks: false
 namespace: labs-ci-cd
 
 # operator manages upgrades etc
-version: v1.8.7
 operator:
   version: argocd-operator.v0.0.14
   channel: alpha
@@ -36,6 +35,7 @@ metrics:
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
+  version: v1.8.7
 
   grafana:
     enabled: true


### PR DESCRIPTION
#### What is this PR About?
default argocd cr version was moved/brokenin #150, fix it 


#### How do we test this?
deploy chart, check argocd version latest 1.8.7

cc: @redhat-cop/day-in-the-life
