### PR TITLE
🐍 add hook for setting admin pwd on install and update version 🐍

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 0.0.14
-appVersion: "8.7.1-community"
+version: 0.0.15
+appVersion: "8.9.0-community"
 home: https://github.com/redhat-cop/helm-charts
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -6,7 +6,7 @@
 
 This chart bootstraps a SonarQube instance with a PostgreSQL database.
 
-`Attribution`: A Fork of thie code was taken from here and customized for OpenShift
+`Attribution`: A Fork of this code was taken from here and customized for OpenShift
 
 https://github.com/Oteemo/charts/tree/master/charts/sonarqube
 
@@ -23,7 +23,7 @@ $ helm install rht-labs-charts/sonarqube
 
 The above command deploys Sonarqube on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
-The default login is admin/admin.
+The default login is admin/admin, but can be overridden.
 
 ## Uninstalling the chart
 
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 
 | Parameter                             | Description                                                                  | Default                                        |
 | ------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------- |
+| `admin.adminPassword`                 | Set Admin Password, also refer "admin.currentAdminPassword"                  | `admin`                                        |
 | `replicaCount`                        | Number of replicas deployed                                                  | `1`                                            |
 | `deploymentStrategy`                  | Deployment strategy                                                          | `{}`                                           |
 | `image.repository`                    | image repository                                                             | `sonarqube`                                    |

--- a/charts/sonarqube/templates/update-admin-pwd-hook.yaml
+++ b/charts/sonarqube/templates/update-admin-pwd-hook.yaml
@@ -1,0 +1,40 @@
+---
+{{- if .Values.account }}
+{{- if .Values.account.adminPassword }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sonarqube.fullname" . }}-change-admin-password-hook
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  {{- range $key, $value := .Values.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  {{- range $key, $value := .Values.adminJobAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  template:
+    metadata:
+      name: {{ template "sonarqube.fullname" . }}-change-admin-password-hook
+      labels:
+        app: {{ template "sonarqube.name" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      {{- range $key, $value := .Values.service.labels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
+        image: "quay.io/openshift/origin-cli:latest"
+        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:{{ default "admin" .Values.account.currentAdminPassword }} -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/users/change_password?login=admin&previousPassword={{ .Values.account.currentAdminPassword | default "admin" | urlquery }}&password={{ .Values.account.adminPassword | default "admin" | urlquery }}"']
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -1,6 +1,11 @@
 ---
 appName: &name sonarqube
 
+# default admin password
+# account:
+#   adminPassword: admin
+#   currentAdminPassword: admin
+
 # dont run any init containers
 initContainers: false
 
@@ -16,7 +21,7 @@ deploymentStrategy: {}
 
 image:
   repository: *name
-  tag: 8.7.1-community
+  tag: 8.9.0-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
 


### PR DESCRIPTION
#### What is this PR About?
- update to community 8.9.0 release
- add hook for setting admin password as part of chart install

#### How do we test this?
tested ok using
```
helm template charts/sonarqube --set account.adminPassword=admin123 --set account.currentAdminPassword=admin
```
cc: @redhat-cop/day-in-the-life
