### PR TITLE
🪲 add serial concurency for release jobs 🪲

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    concurrency: staging_environment
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
#### What is this PR About?
Add serial concurrency for chart releases.

Had a situation where multiple merge at same time, caused chart index.yaml to be out of date:

https://github.com/redhat-cop/helm-charts/commit/aa6ed0ea74189d8b12e89b78dd6970a6b3a03dc4

concurrency doc here:

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency

#### How do we test this?
Should see multiple merges at similar time wait for the "staging_environment" (this is an arbitrary name)

cc: @redhat-cop/day-in-the-life
