### PR TITLE
Postgres image tag updated

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: A Helm chart for deploying Pact Broker on OpenShift 🔗
 name: pact-broker
-version: 0.0.7
+version: 0.0.8
 home: https://github.com/redhat-cop/helm-charts
 icon: https://img.stackshare.io/service/11305/pact.png
 maintainers:

--- a/charts/pact-broker/templates/postgres-dc.yaml
+++ b/charts/pact-broker/templates/postgres-dc.yaml
@@ -83,6 +83,6 @@ spec:
           - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:{{ .Values.postgresql.image.tag | default "9.6" }}
+          name: postgresql:{{ .Values.postgresql.image.tag | default "9.6-el8" }}
           namespace: openshift
       type: ImageChange


### PR DESCRIPTION
#### What is this PR About?
Postgres image tag is updated as `9.6` is no longer a valid tag for OpenShift v4.7

#### How do we test this?
Provide commands/steps to test this PR.

cc: @redhat-cop/day-in-the-life
