### PR TITLE
🐏 scc added for ha mode 🐏

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.0.2
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.4
+version: 1.1.5
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/templates/anyuid-scc.yaml
+++ b/charts/argocd-operator/templates/anyuid-scc.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.argocd_cr.ha.enabled }}
+---
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+metadata:
+  annotations:
+    kubernetes.io/description: anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID.
+  name: {{ .Values.namespace }}-argocd-redis-ha-anyuid
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.name }}-argocd-redis-ha  
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{- end }}

--- a/charts/argocd-operator/templates/anyuid-scc.yaml
+++ b/charts/argocd-operator/templates/anyuid-scc.yaml
@@ -1,42 +1,29 @@
 {{- if .Values.argocd_cr.ha.enabled }}
 ---
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: false
-allowedCapabilities: null
-defaultAddCapabilities: null
-fsGroup:
-  type: RunAsAny
-groups:
-- system:cluster-admins
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  annotations:
-    kubernetes.io/description: anyuid provides all features of the restricted SCC
-      but allows users to run with any UID and any GID.
-  name: {{ .Values.namespace }}-argocd-redis-ha-anyuid
-priority: 10
-readOnlyRootFilesystem: false
-requiredDropCapabilities:
-- MKNOD
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: MustRunAs
-supplementalGroups:
-  type: RunAsAny
-users:
-- system:serviceaccount:{{ .Values.namespace }}:{{ .Values.name }}-argocd-redis-ha  
-volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- persistentVolumeClaim
-- projected
-- secret
+  name: {{ .Values.namespace }}-argocd-redis-ha-anyuid-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gatekeeper-anyuid-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.namespace }}-argocd-redis-ha-anyuid-scc
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.name }}-argocd-redis-ha
+  namespace: {{ .Values.namespace }}
 {{- end }}

--- a/charts/argocd-operator/templates/anyuid-scc.yaml
+++ b/charts/argocd-operator/templates/anyuid-scc.yaml
@@ -17,7 +17,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: gatekeeper-anyuid-scc
+  name: {{ .Values.namespace }}-argocd-redis-ha-anyuid-scc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -49,6 +49,8 @@ argocd_cr:
     size: 1
   ha:
     enabled: false
+    redisProxyImage: haproxy
+    redisProxyVersion: "2.0.4"
 
   rbac:
     defaultPolicy: role:admin


### PR DESCRIPTION
#### What is this PR About?
According to the [documentation](https://argocd-operator.readthedocs.io/en/latest/usage/ha/#openshift), anyuid SCC is required for redis SA.

#### How do we test this?
Provide commands/steps to test this PR.

```bash
helm template --set argocd_cr.ha.enabled=true . ```

cc: @redhat-cop/day-in-the-life
