### PR TITLE
Allow overriding of ArgoCD installPlanApproval

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.0.2
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.5
+version: 1.1.6
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/templates/Subscription.yaml
+++ b/charts/argocd-operator/templates/Subscription.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   channel: {{ .Values.operator.channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.operator.installPlanApproval }}
   name: {{ .Values.operator.name }}
   source: community-operators
   sourceNamespace: openshift-marketplace

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -12,6 +12,7 @@ namespace: labs-ci-cd
 operator:
   version: argocd-operator.v0.0.15
   channel: alpha
+  installPlanApproval: Automatic
   name: argocd-operator
   operatorgroup: true
 


### PR DESCRIPTION
Sometimes it is useful to be able to set the upgrade approval to Manual
on the operator subscription.

#### What is this PR About?
Allow setting installPlanApproval in the helm values, defaulting to Automatic. This will let users specify Manual if required.

#### How do we test this?
Deploy the operator with `installPlanApproval: manual` and verify "Approval" is set to "Manual" in the Openshift console.

cc: @redhat-cop/day-in-the-life
