### PR TITLE
🐾 add operator group per project 🐾

### DIFF
--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -29,14 +29,14 @@ namespaceRoleBinding:
 metrics:
   enabled: false
   prometheus:
-    version: prometheusoperator.0.37.0
+    version: prometheusoperator.0.47.0
     channel: beta
     name: prometheus-operator
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
-  version: v2.0.2
+  version: v2.0.5
 
   grafana:
     enabled: true

--- a/charts/bootstrap-project/Chart.yaml
+++ b/charts/bootstrap-project/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.0.1"
 description: A Helm chart for deploying and managing Openshift projects 🦆
 name: bootstrap-project
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.iconpacks.net/icons/1/free-rocket-icon-1206-thumb.png
 maintainers:

--- a/charts/bootstrap-project/templates/operatorgroup.yaml
+++ b/charts/bootstrap-project/templates/operatorgroup.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.operatorgroup }}
 {{- if .Values.namespaces }}
 {{- range $key := .Values.namespaces }}
+{{- if .operatorgroup }}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/charts/bootstrap-project/values.yaml
+++ b/charts/bootstrap-project/values.yaml
@@ -47,4 +47,3 @@ namespaces:
 serviceaccounts:
 - name: dummy-sa
   namespace: *ci_cd
-

--- a/charts/bootstrap-project/values.yaml
+++ b/charts/bootstrap-project/values.yaml
@@ -3,6 +3,7 @@ dev_namespace: &dev "labs-dev"
 test_namespace: &test "labs-test"
 namespaces:
 - name: *ci_cd
+  operatorgroup: false
   bindings:
   # this labs-devs is the GROUP NAME in IDM
   - name: labs-devs
@@ -17,6 +18,7 @@ namespaces:
     role: admin
   namespace: *ci_cd
 - name: *dev
+  operatorgroup: true
   bindings:
   - name: labs-devs
     kind: Group
@@ -29,6 +31,7 @@ namespaces:
     role: admin
   namespace: *ci_cd
 - name: *test
+  operatorgroup: true
   bindings:
   - name: labs-devs
     kind: Group
@@ -45,4 +48,3 @@ serviceaccounts:
 - name: dummy-sa
   namespace: *ci_cd
 
-operatorgroup: true


### PR DESCRIPTION
#### What is this PR About?
the recent operator group bootstrap is all or nothing.
this change makes it more flexible (can set on namespace basis) when you bootstrap.

#### How do we test this?
we only set OG in dev/test namespaces, not ci-cd in default config
```
helm template charts/bootstrap-project/ | grep -C 5 OperatorGroup
```

cc: @redhat-cop/day-in-the-life
