### PR TITLE
🔐 Feature/sealed secret helper annotations 🔐

### DIFF
--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -29,14 +29,14 @@ namespaceRoleBinding:
 metrics:
   enabled: false
   prometheus:
-    version: prometheusoperator.0.37.0
+    version: prometheusoperator.0.47.0
     channel: beta
     name: prometheus-operator
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
-  version: v2.0.2
+  version: v2.0.5
 
   grafana:
     enabled: true

--- a/charts/helper-sealed-secrets/Chart.yaml
+++ b/charts/helper-sealed-secrets/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v2
 appVersion: "v1"
-description: A Helm Chart for managing Sealed Secrets 🕵️‍♀️
+description: A Helm Chart for managing Sealed Secrets 🕵️‍♀️🔐
 name: helper-sealed-secrets
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/redhat-cop/helm-charts
 icon: https://avatars.githubusercontent.com/u/34656521?s=400&v=4
 maintainers:
   - name: springdo
   - name: ckavili
+  - name: eformat

--- a/charts/helper-sealed-secrets/templates/SealedSecret.yaml
+++ b/charts/helper-sealed-secrets/templates/SealedSecret.yaml
@@ -9,6 +9,10 @@ spec:
     {{- .data | toYaml | nindent 4 }}
   template:
     metadata:
+      annotations:
+        {{- if .annotations }}
+        {{- .annotations | toYaml | nindent 8 }}
+        {{- end}}
       labels:
         {{- if .labels }}
         {{- .labels | toYaml | nindent 8 }}


### PR DESCRIPTION
#### What is this PR About?
add annotation support for sealed secrets
e.g. for both tekton and jenkins we use
```
metadata:
  annotations:
    tekton.dev/git-0: http://gitlab-ce.gitlab.svc.cluster.local
  labels:
    credential.sync.jenkins.openshift.io: "true"
```

#### How do we test this?
add annotations to the app-of-apps e.g.

```
  - name: sealed-secrets
    enabled: false
    source: https://redhat-cop.github.io/helm-charts
    chart_name: helper-sealed-secrets
    source_ref: "1.0.2"
    values:
      secrets:
        - name: git-auth
          type: kubernetes.io/basic-auth
          annotations:
            tekton.dev/git-0: http://gitlab-ce.gitlab-gitlab.svc.cluster.local
          labels:
            credential.sync.jenkins.openshift.io: "true"
          data:
            username: <YOUR_SEALED_SECRET_USERNAME>
            password: <YOUR_SEALED_SECRET_PASSWORD>
```

cc: @redhat-cop/day-in-the-life
