### PR TITLE
🐧 argo 2.1.2 🐧

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.1.0
+appVersion: v2.1.1
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
 version: 1.1.12
@@ -9,4 +9,3 @@ maintainers:
 - name: springdo
 - name: ckavili
 - name: eformat
-- name: mabulgu

--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v2.1.1
+appVersion: v2.1.2
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
 version: 1.1.12

--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.0.5
+appVersion: v2.1.0
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.11
+version: 1.1.12
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   namespace: {{ .Values.namespace }}
 spec:
   containers:

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -36,7 +36,7 @@ metrics:
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
-  version: v2.1.1
+  version: v2.1.2
 
   grafana:
     enabled: true

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -36,7 +36,7 @@ metrics:
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
-  version: v2.1.0
+  version: v2.1.1
 
   grafana:
     enabled: true

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -36,7 +36,7 @@ metrics:
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj123
-  version: v2.0.5
+  version: v2.1.0
 
   grafana:
     enabled: true


### PR DESCRIPTION
#### What is this PR About?
- update to latest argocd release 2.1.0
- cluster-check hook updated delete policy to be more reliable during upgrade - avoid errors like this:
```
Error: UPGRADE FAILED: post-upgrade hooks failed: warning: Hook post-upgrade argocd-operator/templates/wait-for-crd.yaml failed: pods "cluster-check" already exists
```

Please don't merge this yet. It needs - this to merge first.

https://github.com/argoproj-labs/argocd-operator/pull/399

cc: @redhat-cop/day-in-the-life
