### PR TITLE
Jenkins chart updated to be ephemeral by default values

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 1.0.5
+version: 1.0.6
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 1.0.4
+version: 1.0.5
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -49,19 +49,15 @@ The following table lists the configurable parameters of the Jenkins chart and t
 | `services.jenkins-jnlp.port`                     | Port of Jenkins master service                                              | `50000`                                              |
 | `services.jenkins-jnlp.target_port`              | Target port of Jenkins JNLP service                                         | `50000`                                              |
 | `services.jenkins-jnlp.selector`                 | Selector for Jenkins JNLP service to match with Jenkins master deployment   | `jenkins`                                            |
-| `imagestreams.jenkins.external.builder_registry` | Builder image registry for Jenkins custom build                             | `quay.io`                                            |
-| `imagestreams.jenkins.external.builder_repo`     | Builder image repo for Jenkins custom build                                 | `openshift`                                          |
-| `imagestreams.jenkins.external.builder_image`    | Builder image for Jenkins custom build                                      | `origin-jenkins`                                     |
-| `imagestreams.jenkins.external.builder_imagetag` | Builder image tag for Jenkins custom build                                  | `latest`                                             |
-| `buildconfigs.jenkins.build_trigger_secret`      | Webhook Secret for Jenkins master build                                     | `shhhhh-this-is-my-super-duper-secret123-shhhhh`     |
-| `buildconfigs.jenkins.strategy_type`             | Build strategy type for Jenkins master                                      | `Source`                                             |
-| `buildconfigs.jenkins.pull_secret`               | Pull secret for Jenkins master source code repo                             | `''`                                                 |
-| `buildconfigs.jenkins.source_repo`               | Git repo URL for custom Jenkins                                             | `https://github.com/rht-labs/s2i-config-jenkins.git` |
-| `buildconfigs.jenkins.source_repo_ref`           | Git Reference of custom Jenkins repo                                        | `v1.6`                                               |
-| `buildconfigs.jenkins.source_context_dir`        | The directory in the source repository where Jenkins master docker build is | `/`                                                  |
-| `buildconfigs.jenkins.builder_image_name`        | Builder image name for custom build                                         | `jenkins`                                            |
-| `buildconfigs.jenkins.builder_image_tag`         | Builder image tag for custom build                                          | `2`                                                  |
-
+|`buildconfigs.name`| Build and ImageStream name | `''`
+|`buildconfigs.name.strategy_type`| Build strategy type for Jenkins | `Docker`
+|`buildconfigs.name.source_repo`| Git repo URL for custom | `https://github.com/redhat-cop/containers-quickstarts`
+|`buildconfigs.name.source_repo_ref`| Git Reference of custom Jenkins | `master`
+|`buildconfigs.name.source_context_dir`| The directory in the source repository where Jenkins master docker build is | `/` 
+|`buildconfigs.name.builder_image_kind`| Builder image kind | `ImageStreamTag`
+|`buildconfigs.name.builder_image_name`| Builder image name for custom build | `''`
+|`buildconfigs.name.builder_image_tag`| Builder image tag for custom build | `''`
+|`role` | The value of role value for Jenkins Agent ImageStream. It is used for Jenkins sync plugin to discover agents automatically | `jenkins-slave`
 ### Environment Variables
 There are additional environment variables you can set to customize your Jenkins based on your needs. You can update these values on your [values](https://github.com/redhat-cop/helm-charts/blob/master/charts/jenkins/values.yaml#L23) file.
 | Variable                                         | Description                                                                 | Default                                              |

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -38,8 +38,8 @@ The following table lists the configurable parameters of the Jenkins chart and t
 | `deployment.limits.cpu_request`                  | Starting request of cpu that Jenkins master use                             | `500m`                                               |
 | `deployment.limits.cpu_limit`                    | Maximum amount of memory Jenkins master use                                 | `1`                                                  |
 | `deployment.env_vars`                            | Environment variables for Jenkins master                                    | `''`                                                 |
-| `persistence.accessModes`                        | Access mode for Jenkins PV                                                  | `ReadWriteOnce`                                      |
-| `persistence.volumeSize`                         | Volume size for Jenkins PV                                                  | `20Gi`                                               |
+| `persistence.accessModes`                        | Access mode for Jenkins PV                                                  | `''`                                      |
+| `persistence.volumeSize`                         | Volume size for Jenkins PV                                                  | `''`                                               |
 | `services.jenkins.port_name`                     | Port name of service for Jenkins master                                     | `web`                                                |
 | `services.jenkins.port`                          | Port of Jenkins master service                                              | `80`                                                 |
 | `services.jenkins.target_port`                   | Target port of Jenkins master service                                       | `8080`                                               |

--- a/charts/jenkins/templates/imagestreams.yaml
+++ b/charts/jenkins/templates/imagestreams.yaml
@@ -1,3 +1,4 @@
+{{- $label := .Values.role }}
 {{- range $key := .Values.buildconfigs }}
 ---
 kind: ImageStream
@@ -7,7 +8,7 @@ metadata:
   {{- if or (.name | regexFind ".*slave") (.name | regexFind ".*agent")  }}
   labels:
     build: {{ .name }}
-    role: jenkins-agent
+    role: {{ $label | default "jenkins-slave" }}
   {{- end }}
   annotations:
     description: Keeps track of changes in the application image

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -54,9 +54,9 @@ deployment:
     - name: GITLAB_GROUP_NAME
       value: rht-labs
 
-persistence:
-  accessModes: ReadWriteOnce
-  volumeSize: 20Gi
+# persistence:
+#   accessModes: ReadWriteOnce
+#   volumeSize: 20Gi
 
 services:
   - name: *name


### PR DESCRIPTION
#### What is this PR About?
Jenkins should be ephemeral by default as all the configs are driven as IaC via https://github.com/rht-labs/s2i-config-jenkins and Jenkinsfile.  Persistent volume configs can be enabled as described in README and values file.

#### How do we test this?
Provide commands/steps to test this PR.
`helm install...`

cc: @redhat-cop/day-in-the-life
