### PR TITLE
Fix argocd-redis-ha service account name

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.5
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.14
+version: 1.1.15
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/templates/anyuid-scc.yaml
+++ b/charts/argocd-operator/templates/anyuid-scc.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: system:openshift:scc:anyuid
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.namespace }}-argocd-redis-ha
+  name: {{ .Values.name }}-argocd-redis-ha
   namespace: {{ .Values.namespace }}
 {{- end }}


### PR DESCRIPTION
#### What is this PR About?
As per https://github.com/redhat-cop/helm-charts/pull/191/files#r704790946
This PR reverts the service account name in the clusterrolebinding to use {{ .Values.name }} instead of .namespace

cc: @redhat-cop/day-in-the-life
