### PR TITLE
🦑 add gitops-operator chart🦑

### DIFF
--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -217,3 +217,14 @@ setup_file() {
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 0 ]
 }
+
+@test "charts/gitops-operator" {
+  tmp=$(helm_template "charts/gitops-operator")
+
+  namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
+  cmd="conftest test ${tmp} --output tap ${namespaces}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 0 ]
+}

--- a/charts/gitops-operator/.helmignore
+++ b/charts/gitops-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+ci/

--- a/charts/gitops-operator/.test.sh
+++ b/charts/gitops-operator/.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+trap "exit 1" TERM
+export TOP_PID=$$
+
+export project_name="gitops-operator-$(date +'%d%m%Y')"
+
+install() {
+  echo "install - $(pwd)"
+
+  oc new-project ${project_name}
+  helm upgrade --install argocd --set namespaces={${project_name}} -f values.yaml --namespace ${project_name}
+}
+
+test() {
+  echo "test - $(pwd)"
+
+  timeout 2m bash <<"EOT"
+  run() {
+    echo "Attempting oc -n openshift-gitops get deployment/cluster"
+
+    while [[ $(oc get deployment/cluster -o name -n openshift-gitops) != 'deployment.apps/cluster' ]]; do
+      sleep 10
+    done
+  }
+
+  run
+EOT
+
+  oc rollout status deployment/argocd-server -n ${project_name} --watch=true
+
+  timeout 2m bash <<"EOT"
+  run() {
+    host=$(oc get route/argocd-server -o jsonpath='{.spec.host}' -n ${project_name})
+    echo "Attempting $host"
+
+    while [[ $(curl -L -k -s -o /dev/null -w '%{http_code}' https://${host}) != '200' ]]; do
+      sleep 10
+    done
+  }
+
+  run
+EOT
+
+  if [[ $? != 0 ]]; then
+    echo "CURL timed-out. Failing"
+
+    host=$(oc get route/argocd-server -o jsonpath='{.spec.host}' -n ${project_name})
+    curl -L -k -vvv "https://${host}"
+    exit 1
+  fi
+
+  echo "Test complete"
+}
+
+cleanup() {
+  echo "cleanup - $(pwd)"
+  helm uninstall argocd --namespace ${project_name}
+  oc delete project/${project_name}
+}
+
+# Process arguments
+case $1 in
+  install)
+    install
+    ;;
+  test)
+    test
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  *)
+    echo "Not an option"
+    exit 1
+esac

--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+appVersion: v2.1.7
+description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
+name: gitops-operator
+version: 0.0.1
+home: https://github.com/redhat-cop/helm-charts
+icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
+maintainers:
+- name: eformat

--- a/charts/gitops-operator/README.md
+++ b/charts/gitops-operator/README.md
@@ -1,0 +1,51 @@
+# ⚓️ ArgoCD Operator Helm Deploy
+
+ArgoCD Helm Chart customizes and deploys the [RedHat GitOps Operator](https://github.com/redhat-developer/gitops-operator) written by Red Hat.
+
+## Installing the chart
+
+To install the chart from source:
+```bash
+helm upgrade --install argocd -f values.yaml . --create-namespace --namespace labs-ci-cd
+```
+
+The above command creates objects with default naming convention and configuration.
+
+## Removing
+
+To delete the chart:
+```bash
+helm uninstall argocd --namespace labs-ci-cd
+```
+
+## Configuration
+
+The [values.yml](values.yaml) file contains instructions for common chart overrides.
+
+You can install multiple team instances of ArgoCD into different namespaces, just add your namespace to this list. Namespaces should be created separately first e.g. in the bootstrap chart or as shown above for a single namespace called `labs-ci-cd`.
+```yaml
+# add to this list to deploy 'argocd' to multiple namespaces
+namespaces:
+- labs-ci-cd
+```
+
+RBAC for each ArgoCD instance is cluster admin scoped. You will need to modify and adjust the `templates` Cluster Roles if this does not suit your purposes.
+
+The default GitOps ArgoCD instance is _not_ deployed in the `openshift-gitops` operator project. You can enable it by setting `disableDefaultArgoCD: false`
+
+You _do not_ need to override the ArgoCD `applicationInstanceLabelKey`. It is automatically generated based on the namespace name.
+
+Anything configurable in the Operator is passed to the ArgoCD custom resource provided by the Operator. See `argocd_cr` in `values.yaml` for example defaults. For more detailed overview of what's included, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/).
+
+If you wish to use ArgoCD to manage this chart directly (or as a helm chart dependency) you may need to make use of the `ignoreHelmHooks` flag to ignore helm lifecycle hooks. For example as a Helm Chart dependency to UJ bootstrap:
+```bash
+argocd app create bootstrap-journey \
+  --dest-namespace labs-bootstrap \
+  --dest-server https://kubernetes.default.svc \
+  --repo https://github.com/rht-labs/ubiquitous-journey.git \
+  --revision master \
+  --sync-policy automated \
+  --path "bootstrap" \
+  --helm-set gitops-operator.ignoreHelmHooks=true \
+  --values "values.yaml"
+```

--- a/charts/gitops-operator/README.md
+++ b/charts/gitops-operator/README.md
@@ -37,15 +37,14 @@ You _do not_ need to override the ArgoCD `applicationInstanceLabelKey`. It is au
 
 Anything configurable in the Operator is passed to the ArgoCD custom resource provided by the Operator. See `argocd_cr` in `values.yaml` for example defaults. For more detailed overview of what's included, checkout the [ArgoCD Operator Docs](https://argocd-operator.readthedocs.io/en/latest/reference/argocd/).
 
-If you wish to use ArgoCD to manage this chart directly (or as a helm chart dependency) you may need to make use of the `ignoreHelmHooks` flag to ignore helm lifecycle hooks. For example as a Helm Chart dependency to UJ bootstrap:
+If you wish to use ArgoCD to manage this chart directly (or as a helm chart dependency) you may need to make use of the `ignoreHelmHooks` flag to ignore helm lifecycle hooks.
+
+One example might be deploying team instances without the Operator and helm lifecycle hooks.
 ```bash
-argocd app create bootstrap-journey \
-  --dest-namespace labs-bootstrap \
-  --dest-server https://kubernetes.default.svc \
-  --repo https://github.com/rht-labs/ubiquitous-journey.git \
-  --revision master \
-  --sync-policy automated \
-  --path "bootstrap" \
-  --helm-set gitops-operator.ignoreHelmHooks=true \
-  --values "values.yaml"
+helm template foo charts/gitops-operator --set operator= --set ignoreHelmHooks=true | oc apply -f-
+```
+
+Or deploying just the Operator, no helm lifecycle hooks and no team instances.
+```bash
+helm template foo charts/gitops-operator --set namespaces= --set ignoreHelmHooks=true | oc apply -f-
 ```

--- a/charts/gitops-operator/templates/argocd-application-controller-clusterrole.yaml
+++ b/charts/gitops-operator/templates/argocd-application-controller-clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.namespaces }}
+{{- range $ns := .Values.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
+    app.kubernetes.io/part-of: {{ $ns }}
+  name: {{ $ns }}-argocd-application-controller
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+{{- end }}
+{{- end }}

--- a/charts/gitops-operator/templates/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/gitops-operator/templates/argocd-application-controller-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.namespaces }}
+{{- range $ns := .Values.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
+    app.kubernetes.io/part-of: {{ $ns }}
+  name: {{ $ns }}-argocd-application-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $ns }}-argocd-application-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.name }}-argocd-application-controller
+  namespace: {{ $ns }}
+{{- end }}
+{{- end }}

--- a/charts/gitops-operator/templates/argocd-cr.yaml
+++ b/charts/gitops-operator/templates/argocd-cr.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.namespaces }}
+{{- range $ns := .Values.namespaces }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: {{ $.Values.name }}
+  labels:
+    app: {{ $.Values.name }}
+  {{- if not $.Values.ignoreHelmHooks }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
+  {{- end }}
+  namespace: {{ $ns }}
+spec:
+  applicationInstanceLabelKey: rht-gitops.com/{{ $ns }}
+  {{- if $.Values.argocd_cr }}
+  {{- $.Values.argocd_cr | toYaml | trim | nindent 2 }}
+  {{- end }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: default
+  namespace: {{ $ns }}
+spec:
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: '*'
+  sourceRepos:
+    - '*'
+status: {}
+{{- end }}
+{{- end }}

--- a/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
+++ b/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.namespaces }}
+{{- range $ns := .Values.namespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: argocd-server
+    app.kubernetes.io/name: {{ $ns }}-argocd-server
+    app.kubernetes.io/part-of: {{ $ns }}
+  name: {{ $ns }}-argocd-server
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - delete  # supports deletion a live object in UI
+  - get     # supports viewing live object manifest in UI
+  - patch   # supports `argocd app patch`
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list    # supports listing events in UI
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get     # supports viewing pod logs from UI
+{{- end }}
+{{- end }}

--- a/charts/gitops-operator/templates/argocd-server-clusterrolebinding.yaml
+++ b/charts/gitops-operator/templates/argocd-server-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.namespaces }}
+{{- range $ns := .Values.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: argocd-server
+    app.kubernetes.io/name: {{ $ns }}-argocd-server
+    app.kubernetes.io/part-of: {{ $ns }}
+  name: {{ $ns }}-argocd-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $ns }}-gitops-argocd-server
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.name }}-argocd-server
+  namespace: {{ $ns }}
+{{- end }}
+{{- end }}

--- a/charts/gitops-operator/templates/crd-reader.yaml
+++ b/charts/gitops-operator/templates/crd-reader.yaml
@@ -1,0 +1,36 @@
+{{- if not .Values.ignoreHelmHooks }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-reader
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - 'customresourcedefinitions'
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-reader-binding
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gitops-operator/templates/subscription.yaml
+++ b/charts/gitops-operator/templates/subscription.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator }}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -17,3 +18,4 @@ spec:
       value:  {{ .Values.operator.disableDefaultArgoCD | quote }}
     - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
       value: {{ join "," .Values.namespaces | quote }}
+{{- end }}

--- a/charts/gitops-operator/templates/subscription.yaml
+++ b/charts/gitops-operator/templates/subscription.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: openshift-operators
+spec:
+  channel: {{ .Values.operator.channel }}
+  installPlanApproval: {{ .Values.operator.installPlanApproval }}
+  name: {{ .Values.operator.name }}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: {{ .Values.operator.version | quote }}
+  config:
+    env:
+    - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+      value:  {{ .Values.operator.disableDefaultArgoCD | quote }}
+    - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+      value: {{ join "," .Values.namespaces | quote }}

--- a/charts/gitops-operator/templates/wait-for-crd.yaml
+++ b/charts/gitops-operator/templates/wait-for-crd.yaml
@@ -1,0 +1,22 @@
+{{- if not .Values.ignoreHelmHooks }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cluster-check 
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  namespace: {{ .Release.Namespace }}
+spec:
+  containers:
+  - name: crd-check 
+    image: quay.io/openshift/origin-cli:latest
+    imagePullPolicy: IfNotPresent
+    command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io applications.argoproj.io appprojects.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  serviceAccount: default
+  serviceAccountName: default
+{{- end }}

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -25,7 +25,6 @@ argocd_cr:
     policy: |
       g, system:cluster-admins, role:admin
     scopes: '[groups]'
-  repositoryCredentials: null
   resourceExclusions: |
     - apiGroups:
         - tekton.dev

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -1,0 +1,53 @@
+---
+# name of instances
+name: argocd
+
+# this is for argo type deployments of this chart (set to true)
+ignoreHelmHooks: false
+
+# add to this list to deploy team instances to these namespaces
+namespaces:
+- labs-ci-cd
+
+# operator manages upgrades
+operator:
+  version: openshift-gitops-operator.v1.3.1
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  disableDefaultArgoCD: true
+
+# https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
+argocd_cr:
+  version: v2.1.7
+  rbac:
+    defaultPolicy: 'role:admin'
+    policy: |
+      g, system:cluster-admins, role:admin
+    scopes: '[groups]'
+  repositoryCredentials: null
+  resourceExclusions: |
+    - apiGroups:
+        - tekton.dev
+      clusters:
+        - '*'
+      kinds:
+        - TaskRun
+        - PipelineRun
+  server:
+    route:
+      enabled: true
+      tls:
+        termination: reencrypt
+  dex:
+    openShiftOAuth: true
+
+  initialRepositories: |
+    - name: ubiquitous-journey
+      url: https://github.com/rht-labs/ubiquitous-journey.git
+    - name: redhat-cop
+      type: helm
+      url: https://redhat-cop.github.io/helm-charts
+
+  # configure your repo credential template (override this)
+  repositoryCredentials: null


### PR DESCRIPTION
#### What is this PR About?
Helm chart for Red Hat GitOps Operator. Can deploy ArgoCD instances to multiple namespaces.
See README.md for more details. Contains RBAC similar to the Community ArgoCD chart (cluster admin).

#### How do we test this?
test.sh
```
helm upgrade --install argocd charts/gitops-operator --create-namespace --namespace labs-ci-cd
```

cc: @redhat-cop/day-in-the-life
