### PR TITLE
🐶 FIX - Broken variables in CRD. Secret location. Proper Release naming 🐶

### DIFF
--- a/charts/argocd-operator/Chart.yaml
+++ b/charts/argocd-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.5
 description: A Helm chart for customising the deployment of the ArgoCD Operator ⚓️
 name: argocd-operator
-version: 1.1.15
+version: 1.2.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://cncf-branding.netlify.app/img/projects/argo/stacked/color/argo-stacked-color.png
 maintainers:

--- a/charts/argocd-operator/templates/ArgoCD.yaml
+++ b/charts/argocd-operator/templates/ArgoCD.yaml
@@ -11,14 +11,8 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "25"
   {{- end }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 spec:
-  # some defaults 🤷‍♂️
-  insecure: false
-  statusBadgeEnabled: true
-  usersAnonymousEnabled: false
-  dex:
-    openShiftOAuth: true
   {{- if .Values.argocd_cr }}
   {{- .Values.argocd_cr | toYaml | trim | nindent 2 }}
   {{- end }}

--- a/charts/argocd-operator/templates/ClusterRole.yaml
+++ b/charts/argocd-operator/templates/ClusterRole.yaml
@@ -5,9 +5,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: {{ .Values.namespace }}-argocd-application-controller
-    app.kubernetes.io/part-of: {{ .Values.namespace }}
-  name: {{ .Values.namespace }}-argocd-application-controller
+    app.kubernetes.io/name: {{ include "argocd-operator.ns" . }}-argocd-application-controller
+    app.kubernetes.io/part-of: {{ include "argocd-operator.ns" . }}
+  name: {{ include "argocd-operator.ns" . }}-argocd-application-controller
 rules:
 - apiGroups:
   - '*'

--- a/charts/argocd-operator/templates/ClusterRoleBinding.yaml
+++ b/charts/argocd-operator/templates/ClusterRoleBinding.yaml
@@ -5,17 +5,17 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: {{ .Values.namespace }}-argocd-application-controller
-    app.kubernetes.io/part-of: {{ .Values.namespace }}
-  name: {{ .Values.namespace }}-argocd-application-controller
+    app.kubernetes.io/name: {{ include "argocd-operator.ns" . }}-argocd-application-controller
+    app.kubernetes.io/part-of: {{ include "argocd-operator.ns" . }}
+  name: {{ include "argocd-operator.ns" . }}-argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.namespace }}-argocd-application-controller
+  name: {{ include "argocd-operator.ns" . }}-argocd-application-controller
 {{- if not .Values.namespaceRoleBinding.enabled }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.name }}-argocd-application-controller
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 {{- end }}
 {{- end }}

--- a/charts/argocd-operator/templates/OperatorGroup.yaml
+++ b/charts/argocd-operator/templates/OperatorGroup.yaml
@@ -5,12 +5,12 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: {{ .Values.namespace }}
-  generateName: {{ .Values.namespace }}-
-  namespace: {{ .Values.namespace }}
+  name: {{ include "argocd-operator.ns" . }}
+  generateName: {{ include "argocd-operator.ns" . }}-
+  namespace: {{ include "argocd-operator.ns" . }}
 spec:
   targetNamespaces:
-  - {{ .Values.namespace }}
+  - {{ include "argocd-operator.ns" . }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/argocd-operator/templates/PrometheusSubscription.yaml
+++ b/charts/argocd-operator/templates/PrometheusSubscription.yaml
@@ -4,7 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: prometheus-operator
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 spec:
   channel: beta
   installPlanApproval: Automatic

--- a/charts/argocd-operator/templates/Secret.yaml
+++ b/charts/argocd-operator/templates/Secret.yaml
@@ -1,12 +1,11 @@
-{{- if .Values.argocd_cr.secrets }}
-{{- $namespace := .Values.namespace }}
-{{- range $key := .Values.argocd_cr.secrets }}
+{{- if .Values.secrets }}
+{{- range $key := .Values.secrets }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ $namespace }}
+  namespace: {{ include "argocd-operator.ns" $ }}
   labels:
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/part-of: argocd

--- a/charts/argocd-operator/templates/Subscription.yaml
+++ b/charts/argocd-operator/templates/Subscription.yaml
@@ -5,7 +5,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 spec:
   channel: {{ .Values.operator.channel }}
   installPlanApproval: {{ .Values.operator.installPlanApproval }}

--- a/charts/argocd-operator/templates/anyuid-scc.yaml
+++ b/charts/argocd-operator/templates/anyuid-scc.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argocd-redis-ha-anyuid-scc
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12,5 +12,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.name }}-argocd-redis-ha
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 {{- end }}

--- a/charts/argocd-operator/templates/crd-reader.yaml
+++ b/charts/argocd-operator/templates/crd-reader.yaml
@@ -32,5 +32,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 {{- end }}

--- a/charts/argocd-operator/templates/helpers.tpl
+++ b/charts/argocd-operator/templates/helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Namespace from Values or Release Name
+*/}}
+{{- define "argocd-operator.ns" -}}
+{{- if .Values.namespace }}
+{{- .Values.namespace | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: cluster-check 
+  name: cluster-check
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ include "argocd-operator.ns" . }}
 spec:
   containers:
-  - name: crd-check 
+  - name: crd-check
     image: quay.io/openshift/origin-cli:4.7
     imagePullPolicy: IfNotPresent
     command: ['sh', '-c', 'while [ true ]; do oc get crd argocds.argoproj.io applications.argoproj.io appprojects.argoproj.io argocdexports.argoproj.io; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']

--- a/charts/argocd-operator/templates/wait-for-crd.yaml
+++ b/charts/argocd-operator/templates/wait-for-crd.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "argocd-operator.ns" . }}
 spec:
   containers:
   - name: crd-check 

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -44,7 +44,7 @@ secrets:
 argocd_cr:
   applicationInstanceLabelKey: rht-labs.com/uj1234
   version: v2.1.5
-  
+
   statusBadgeEnabled: true
   usersAnonymousEnabled: false
   dex:

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -6,11 +6,11 @@ name: argocd
 # this is for argo type deployments (set to true) dont deploy helm hooked resources
 ignoreHelmHooks: false
 
-namespace: labs-ci-cd
+# namespace: labs-ci-cd
 
 # operator manages upgrades etc
 operator:
-  version: argocd-operator.v0.0.15
+  version: argocd-operator.v0.1.0
   channel: alpha
   installPlanApproval: Automatic
   name: argocd-operator
@@ -33,10 +33,21 @@ metrics:
     channel: beta
     name: prometheus-operator
 
+secrets:
+  - name: git-auth
+    username: 'springdo'
+    password: 'pass1234'
+    sshPrivateKey: ''
+
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  applicationInstanceLabelKey: rht-labs.com/uj123
+  applicationInstanceLabelKey: rht-labs.com/uj1235
   version: v2.1.5
+  
+  statusBadgeEnabled: true
+  usersAnonymousEnabled: false
+  dex:
+    openShiftOAuth: true
 
   grafana:
     enabled: true
@@ -59,6 +70,10 @@ argocd_cr:
   server:
     route:
       enabled: true
+      tls:
+        termination: passthrough
+        insecureEdgeTerminationPolicy: Redirect
+      wildcardPolicy: None
     autoscale:
       enabled: false
     service:
@@ -84,14 +99,3 @@ argocd_cr:
       usernameSecret:
         key: username
         name: argocd-privaterepo
-  secrets:
-    - name: argocd-privaterepo
-      username: 'user123'
-      password: 'pass123'
-      sshPrivateKey: ''
-
-  # examples
-  accounts:
-    accounts.admin: login, apiKey
-    accounts.alice: apiKey
-    accounts.alice.enabled: 'false'

--- a/charts/argocd-operator/values.yaml
+++ b/charts/argocd-operator/values.yaml
@@ -6,6 +6,7 @@ name: argocd
 # this is for argo type deployments (set to true) dont deploy helm hooked resources
 ignoreHelmHooks: false
 
+# use the RELEASENAME if you want otherwise set this when helm template
 # namespace: labs-ci-cd
 
 # operator manages upgrades etc
@@ -34,14 +35,14 @@ metrics:
     name: prometheus-operator
 
 secrets:
-  - name: git-auth
-    username: 'springdo'
+  - name: argocd-privaterepo
+    username: 'user'
     password: 'pass1234'
     sshPrivateKey: ''
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  applicationInstanceLabelKey: rht-labs.com/uj1235
+  applicationInstanceLabelKey: rht-labs.com/uj1234
   version: v2.1.5
   
   statusBadgeEnabled: true


### PR DESCRIPTION
#### What is this PR About?
looks like some of the properties in the CRD for argocd have been sunset causing breaking changes. I also moved the namespace from a variable to a release or optionally passed as a var. This was to make it easier when installing.. no more double setting the ns like we used to  `--namespace my-ci-cd --create-namespace --set namespace=my-ci-cd`

#### How do we test this?
helm install ....


cc: @redhat-cop/day-in-the-life
