### PR TITLE
Fix ArgoCD server cluster role name

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.1.7
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
+++ b/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
@@ -5,9 +5,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: argocd-server
-    app.kubernetes.io/name: {{ $ns }}-argocd-server
+    app.kubernetes.io/name: {{ $ns }}-gitops-argocd-server
     app.kubernetes.io/part-of: {{ $ns }}
-  name: {{ $ns }}-argocd-server
+  name: {{ $ns }}-gitops-argocd-server
 rules:
 - apiGroups:
   - '*'


### PR DESCRIPTION
#### What is this PR About?
When deploying ArgoCD using the GitOps operator, the created cluster role should contain `-gitops-` in the name since the cluster role binding references <ns>-gitops-argocd-server. Without this, the ClusterRole `<ns>-argocd-server` is created but not bound.

ClusterRoleBinding in helm template:
https://github.com/redhat-cop/helm-charts/blob/gitops-operator-0.1.2/charts/gitops-operator/templates/argocd-server-clusterrolebinding.yaml#L15

#### How do we test this?
This fixes the error after operator deployment when checking the sync status of a resource in the ArgoCD UI.

`
Unable to load data: events is forbidden: User "system:serviceaccount:<ns>:argocd-argocd-server" cannot list resource "events" in API group "" at the cluster scope: RBAC: clusterrole.rbac.authorization.k8s.io "<ns>-gitops-argocd-server" not found
`

cc: @redhat-cop/day-in-the-life @eformat 
