### PR TITLE
🩴 9.2.4-community 🩴

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 0.0.17
-appVersion: "9.1.0-community"
+version: 0.1.0
+appVersion: "9.2.4-community"
 home: https://github.com/redhat-cop/helm-charts
 keywords:
   - coverage

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -26,7 +26,7 @@ deploymentStrategy: {}
 
 image:
   repository: *name
-  tag: 9.1.0-community
+  tag: 9.2.4-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
 


### PR DESCRIPTION
#### What is this PR About?

update to latest 9.2.4-community which does not have log4jshell vuln:

![Screenshot from 2021-12-21 10-23-31](https://user-images.githubusercontent.com/712608/146850830-2f7a29e0-0def-494a-8b4a-48c2229ecb30.png)


#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
