### PR TITLE
Bumped Cluster Version & Fixed Service Account

### DIFF
--- a/charts/ansible-automation-platform/Chart.yaml
+++ b/charts/ansible-automation-platform/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
-appVersion: v2.0.0
-description: A Helm chart for customising the deployment of the Ansible Automation Platform Operator
+appVersion: v2.0.1
+description: A Helm chart for customizing the deployment of the Ansible Automation Platform Operator
 name: ansible-automation-platform
-version: 0.0.2
+version: 0.0.3
 home: https://github.com/redhat-cop/helm-charts
 maintainers:
 - name: paulbarfuss
+- name: ecda909

--- a/charts/ansible-automation-platform/templates/AnsibleAutomationController.yaml
+++ b/charts/ansible-automation-platform/templates/AnsibleAutomationController.yaml
@@ -30,16 +30,22 @@ spec:
   {{- if .Values.automationController.admin_password }}
   admin_password_secret: "ansible-automation-controller-custom-admin-password"
   {{- end }}
+  {{- if .Values.automationController.web_resource_requirements }}
   web_resource_requirements:
   {{- with .Values.automationController.web_resource_requirements }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.automationController.task_resource_requirements }}
   task_resource_requirements:
   {{- with .Values.automationController.task_resource_requirements }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.automationController.ee_resource_requirements }}
   ee_resource_requirements:
   {{- with .Values.automationController.ee_resource_requirements }}
   {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/ansible-automation-platform/templates/wait-for-crd.yaml
+++ b/charts/ansible-automation-platform/templates/wait-for-crd.yaml
@@ -14,7 +14,7 @@ spec:
     - name: crd-check 
       image: quay.io/openshift/origin-cli:4.7
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'while [ true ]; do oc get automationcontrollers.automationcontroller.ansible.com; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
+      command: ['sh', '-c', 'while [ true ]; do oc get crd automationcontrollers.automationcontroller.ansible.com; if [ $? -eq 0 ]; then break; fi ; sleep 5s; done']
   restartPolicy: Never
   terminationGracePeriodSeconds: 0
   serviceAccount: default

--- a/charts/ansible-automation-platform/values.yaml
+++ b/charts/ansible-automation-platform/values.yaml
@@ -11,7 +11,7 @@ namespace: ansible-automation-platform
 
 # Subscription and OperatorGroup
 operator:
-  version: ansible-automation-platform-operator.v2.0.0
+  version: aap-operator.v2.0.1-0.1635279521
   channel: early-access
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator

--- a/tmp/test.yaml
+++ b/tmp/test.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-reader-binding
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ansible-automation-platform


### PR DESCRIPTION
#### What is this PR About?
This PR has the following changes:

- Bumping up the cluster version (v2.0.0 --> v2.0.1) 
- Fixing our service accounts within the automation controller (addition of "If" statements)
- Adding an oc cli config within the crd-check pod

#### How do we test this?

These changes were tested against the SLT Sandbox environment, so we can check the deployment there: https://console-openshift-console.apps.slt.core.rht-labs.com/k8s/ns/ansible-automation-platform/pods or we can perform the following steps to carry-out a deployment from scratch...

--> Run Locally 🏡
1. Gather you "oc login" credentials from the OpenShift UI 
`oc login --token=<token_here> --server=https://api.slt.core.rht-labs.com:6443`
2. Navigate to Ansible Automation Platform directory 
`cd charts/ansible-automation-platform`
3. Run helm install command
`helm install -f values.yaml ansible-automation-platform . --create-namespace --namespace ansible-automation-platform`

Hopefully all is well! 👨🏾‍💻🎉

cc: @redhat-cop/day-in-the-life
