### PR TITLE
🫑 v2.2.4 argocd 🫑

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.2.3
+appVersion: v2.2.4
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.2.2
+version: 0.2.3
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -11,7 +11,7 @@ namespaces:
 
 # operator manages upgrades
 operator:
-  version: openshift-gitops-operator.v1.3.2
+  version: openshift-gitops-operator.v1.4.1
   channel: stable
   installPlanApproval: Automatic
   name: openshift-gitops-operator
@@ -28,7 +28,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.2.3
+  version: v2.2.4
   rbac:
     defaultPolicy: 'role:admin'
     policy: |


### PR DESCRIPTION
#### What is this PR About?
update to security patch argocd 2.2.4 release.

- https://github.com/argoproj/argo-cd/security/advisories/GHSA-63qx-x74g-jcr7

updated to latest gitops-operator csv version v1.4.1

#### How do we test this?
helm installed chart OK into 4.9.17 cluster

cc: @redhat-cop/day-in-the-life
