### PR TITLE
🩹 v2.2.5 argocd 🩹

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.2.4
+appVersion: v2.2.5
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.2.3
+version: 0.2.4
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -28,7 +28,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.2.4
+  version: v2.2.5
   rbac:
     defaultPolicy: 'role:admin'
     policy: |


### PR DESCRIPTION
#### What is this PR About?
update to lateset argocd 2.2.5 release.
fixes a nit introduced in previous security bug fix release.

#### How do we test this?
helm installed chart OK into 4.9.17 cluster

cc: @redhat-cop/day-in-the-life
