### PR TITLE
Added ability to use configuration-as-code on start of Jenkins

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 1.0.6
+version: 1.0.7
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -9,3 +9,4 @@ maintainers:
   - name: springdo
   - name: ckavili
   - name: eformat
+

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -9,4 +9,3 @@ maintainers:
   - name: springdo
   - name: ckavili
   - name: eformat
-

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -57,7 +57,9 @@ The following table lists the configurable parameters of the Jenkins chart and t
 |`buildconfigs.name.builder_image_kind`| Builder image kind | `ImageStreamTag`
 |`buildconfigs.name.builder_image_name`| Builder image name for custom build | `''`
 |`buildconfigs.name.builder_image_tag`| Builder image tag for custom build | `''`
-|`role` | The value of role value for Jenkins Agent ImageStream. It is used for Jenkins sync plugin to discover agents automatically | `jenkins-slave`
+|`role` | The value of role value for Jenkins Agent ImageStream. It is used for Jenkins sync plugin to discover agents automatically | `jenkins-slave` |
+|`configAsCode.configMap` | The name of the ConfigMap to create and associate with the Jenkins DeploymentConfig in order to be used for Configuration-as-Code | `null` |
+|`configAsCode.body` | The body content of the configuration-as-code which will be stored in the ConfigMap, mounted in the Jenkins pod, and read in as Configuration by the Configuration-as-Code plugin | `null` |
 ### Environment Variables
 There are additional environment variables you can set to customize your Jenkins based on your needs. You can update these values on your [values](https://github.com/redhat-cop/helm-charts/blob/master/charts/jenkins/values.yaml#L23) file.
 | Variable                                         | Description                                                                 | Default                                              |

--- a/charts/jenkins/templates/configuration-as-code-configmap.yaml
+++ b/charts/jenkins/templates/configuration-as-code-configmap.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: jenkin{{ .Values.configAsCode.configMap }}
+  name: {{ .Values.configAsCode.configMap }}
 data:
   JCasC.yaml: |
 {{- .Values.configAsCode.body | nindent 4 }}

--- a/charts/jenkins/templates/configuration-as-code-configmap.yaml
+++ b/charts/jenkins/templates/configuration-as-code-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.configAsCode }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: jenkin{{ .Values.configAsCode.configMap }}
+data:
+  JCasC.yaml: |
+{{- .Values.configAsCode.body | nindent 4 }}
+{{- end }}

--- a/charts/jenkins/templates/deploymentconfig.yaml
+++ b/charts/jenkins/templates/deploymentconfig.yaml
@@ -45,6 +45,10 @@ spec:
           value: 'false'
         - name: JENKINS_OPTS
           value: '--sessionTimeout=180'
+        {{- if .Values.configAsCode }}
+        - name: CASC_JENKINS_CONFIG
+          value: /var/lib/jenkins/config-as-code
+        {{- end }}
         {{- range $key := .Values.deployment.env_vars }}
         {{- if .value }}
         - name: {{ .name }}
@@ -82,18 +86,33 @@ spec:
           capabilities: {}
           privileged: false
         terminationMessagePath: /dev/termination-log
-        {{- if .Values.persistence }}
+        {{- if or (.Values.persistence) (.Values.configAsCode) }}
         volumeMounts:
+        {{- end }}
+        {{- if .Values.persistence }}
         - mountPath: /var/lib/jenkins
-          name: {{ .Values.appName }}-data {{ end }}
+          name: {{ .Values.appName }}-data
+        {{- end }}
+        {{- if .Values.configAsCode }}
+        - mountPath: /var/lib/jenkins/config-as-code
+          name: config-as-code
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: {{ .Values.appName }}
-      {{- if .Values.persistence }}
+      {{- if or (.Values.persistence) (.Values.configAsCode) }}
       volumes:
+      {{- end }}
+      {{- if .Values.persistence }}
       - name: {{ .Values.appName }}-data
         persistentVolumeClaim:
           claimName: {{ .Values.appName }}
+      {{- end }}
+      {{- if .Values.configAsCode }}
+      - name: config-as-code
+        configMap:
+          name: {{ .Values.configAsCode.configMap }}
+          defaultMode: 420
       {{- end }}
   triggers:
   - imageChangeParams:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -145,12 +145,11 @@ buildconfigs:
 #             }
 #             orphanedItemStrategy {
 #               discardOldItems {
-#                 // Set to 0 to autoprune jobs once branch is deleted 
+#                 // Set to 0 to autoprune jobs once branch is deleted
 #                 numToKeep(0)
 #               }
 #             }
 #           }
-
 #           queue('clms-fe')
 #       - script: |
 #           multibranchPipelineJob('clms-api') {
@@ -186,12 +185,11 @@ buildconfigs:
 #             }
 #             orphanedItemStrategy {
 #               discardOldItems {
-#                 // Set to 0 to autoprune jobs once branch is deleted 
+#                 // Set to 0 to autoprune jobs once branch is deleted
 #                 numToKeep(0)
 #               }
 #             }
 #           }
-
 #           queue('clms-fe')
 #     unclassified:
 #       giteaServers:

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -105,7 +105,6 @@ buildconfigs:
 ##
 ## The example below shows how to automatically seed multibranch pipelines using the Gitea
 ## plugins and JobDSL.
-
 # configAsCode:
 #   configMap: jenkins-configuration-as-code
 #   body: |

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -99,3 +99,105 @@ buildconfigs:
   - name: jenkins-agent-python
   - name: jenkins-agent-ruby
   - name: jenkins-agent-rust
+
+## This works with the Jenkins Configuration-as-Code plugin. You can put all sorts of declarative configuration
+## into this `body` and Jenkins will load it on start, even when using ephemeral Jenkins.
+##
+## The example below shows how to automatically seed multibranch pipelines using the Gitea
+## plugins and JobDSL.
+
+# configAsCode:
+#   configMap: jenkins-configuration-as-code
+#   body: |
+#     jenkins:
+#       systemMessage: "Controlled by Configuration as Code"
+#     jobs:
+#       - script: |
+#           multibranchPipelineJob('clms-fe') {
+#             triggers {
+#               cron('@daily')
+#             }
+#             configure {
+#               it / sources / 'data' / 'jenkins.branch.BranchSource' << {
+#                 source(class: 'org.jenkinsci.plugin.gitea.GiteaSCMSource') {
+#                   id("clms-fe")
+#                   credentialsId("clms-devops-gitea-pipeline-credentials")
+#                   repoOwner("CLMS")
+#                   repository("frontend")
+#                   serverUrl('http://gitea:3000')
+#                   traits {
+#                     originPullRequestDiscoveryTrait(class: 'org.jenkinsci.plugin.gitea.OriginPullRequestDiscoveryTrait') {
+#                       strategyId(2)
+#                     }
+#                     branchDiscoveryTrait(class: 'org.jenkinsci.plugin.gitea.BranchDiscoveryTrait') {
+#                       strategyId(1)
+#                     }
+#                     cloneOptionTrait {
+#                       extension {
+#                         noTags(true)
+#                         shallow(false)
+#                         reference("")
+#                         timeout(10)
+#                       }
+#                     }
+#                   }
+#                 }
+#               }
+#             }
+#             orphanedItemStrategy {
+#               discardOldItems {
+#                 // Set to 0 to autoprune jobs once branch is deleted 
+#                 numToKeep(0)
+#               }
+#             }
+#           }
+
+#           queue('clms-fe')
+#       - script: |
+#           multibranchPipelineJob('clms-api') {
+#             triggers {
+#               cron('@daily')
+#             }
+#             configure {
+#               it / sources / 'data' / 'jenkins.branch.BranchSource' << {
+#                 source(class: 'org.jenkinsci.plugin.gitea.GiteaSCMSource') {
+#                   id("clms-api")
+#                   credentialsId("clms-devops-gitea-pipeline-credentials")
+#                   repoOwner("CLMS")
+#                   repository("clms-api")
+#                   serverUrl('http://gitea:3000')
+#                   traits {
+#                     originPullRequestDiscoveryTrait(class: 'org.jenkinsci.plugin.gitea.OriginPullRequestDiscoveryTrait') {
+#                       strategyId(2)
+#                     }
+#                     branchDiscoveryTrait(class: 'org.jenkinsci.plugin.gitea.BranchDiscoveryTrait') {
+#                       strategyId(1)
+#                     }
+#                     cloneOptionTrait {
+#                       extension {
+#                         noTags(true)
+#                         shallow(false)
+#                         reference("")
+#                         timeout(10)
+#                       }
+#                     }
+#                   }
+#                 }
+#               }
+#             }
+#             orphanedItemStrategy {
+#               discardOldItems {
+#                 // Set to 0 to autoprune jobs once branch is deleted 
+#                 numToKeep(0)
+#               }
+#             }
+#           }
+
+#           queue('clms-fe')
+#     unclassified:
+#       giteaServers:
+#         servers:
+#         - credentialsId: "clms-devops-gitea-pipeline-credentials"
+#           displayName: "Gitea"
+#           manageHooks: true
+#           serverUrl: "http://gitea:3000"


### PR DESCRIPTION
#### What is this PR About?
This PR allows users of Jenkins on Kubernetes to leverage the Configuration-as-Code plugin to configure the
CI platform in a declarative manner. This is an alternative to using the `init.groovy.d` and is far less complex. The example in the `values.yaml` shows how to seed multibranch pipelines using the Gitea plugin. 

#### How do we test this?
1. Install Jenkins using the chart as an Ephemeral instance and without the Configuration-as-Code enabled
2. From the Jenkins Web Console, configure things like Gitea/SonarQube/etc...
3. Navigate to the "Manage Jenkins" section and to "Configuration as Code"
4. View the configuration
5. Select sections of the YAML corresponding to your manually configured settings and copy them to the Helm chart's values
6. Update the Helm chart with the new settings
7. You should notice that:
    * A new ConfigMap has been created containing the content from the `body` of the `configAsCode` key in Values.yaml
    * The new ConfigMap has been provisioned as a volume/volumeMount in the Jenkins DeploymentConfig
    * A new environment variable has been added to the Jenkins DeploymentConfig pointing Jenkins to the configuration-as-code
8. The ConfigChange trigger should re-deploy Jenkins
9. When Jenkins has become available after the rollout, you should still see the items copied into the configuration-as-code

cc: @redhat-cop/day-in-the-life
