### PR TITLE
🦕 add custom rbac and team cluster scoped 🦕

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.1
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.3.0
+version: 0.3.2
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.2.6
+appVersion: v2.2.7
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.2.5
+version: 0.2.6
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.2.7
+appVersion: v2.3.1
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.2.6
+version: 0.3.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/README.md
+++ b/charts/gitops-operator/README.md
@@ -41,7 +41,7 @@ namespaces:
 
 RBAC for each ArgoCD instance is `cluster-admin` scoped by default. You can create `namespaced` ArgoCD instances by specifying `teamInstancesAreClusterScoped: false`. This setting does not deploy any excess RBAC and uses the defaults from the gitops-operator.
 
-If you want fine-grained access, you will need to modify and adjust the `templates` Cluster Roles if the defaults do not suit your purpose.
+If you want fine-grained access, you may set `clusterRoleRulesController` and `clusterRoleRulesServer` with Role rules that suit your purpose.
 
 The default GitOps ArgoCD instance is _not_ deployed in the `openshift-gitops` operator project. You can enable it by setting `disableDefaultArgoCD: false`
 

--- a/charts/gitops-operator/README.md
+++ b/charts/gitops-operator/README.md
@@ -39,7 +39,9 @@ namespaces:
 - labs-ci-cd
 ```
 
-RBAC for each ArgoCD instance is cluster admin scoped. You will need to modify and adjust the `templates` Cluster Roles if this does not suit your purposes.
+RBAC for each ArgoCD instance is `cluster-admin` scoped by default. You can create `namespaced` ArgoCD instances by specifying `teamInstancesAreClusterScoped: false`. This setting does not deploy any excess RBAC and uses the defaults from the gitops-operator.
+
+If you want fine-grained access, you will need to modify and adjust the `templates` Cluster Roles if the defaults do not suit your purpose.
 
 The default GitOps ArgoCD instance is _not_ deployed in the `openshift-gitops` operator project. You can enable it by setting `disableDefaultArgoCD: false`
 

--- a/charts/gitops-operator/templates/argocd-application-controller-clusterrole.yaml
+++ b/charts/gitops-operator/templates/argocd-application-controller-clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.namespaces }}
+{{- if and (.Values.namespaces) (.Values.teamInstancesAreClusterScoped) }}
+{{- $rules := .Values.clusterRoleRulesController }}
 {{- range $ns := .Values.namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -9,6 +10,9 @@ metadata:
     app.kubernetes.io/name: {{ $ns }}-argocd-application-controller
     app.kubernetes.io/part-of: {{ $ns }}
   name: {{ $ns }}-argocd-application-controller
+{{- if $rules }}
+{{- toYaml $rules | nindent 0 }}
+{{- else }}
 rules:
 - apiGroups:
   - '*'
@@ -20,5 +24,6 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gitops-operator/templates/argocd-application-controller-clusterrolebinding.yaml
+++ b/charts/gitops-operator/templates/argocd-application-controller-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.namespaces }}
+{{- if and (.Values.namespaces) (.Values.teamInstancesAreClusterScoped) }}
 {{- range $ns := .Values.namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
+++ b/charts/gitops-operator/templates/argocd-server-clusterrole.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.namespaces }}
+{{- if and (.Values.namespaces) (.Values.teamInstancesAreClusterScoped) }}
+{{- $rules := .Values.clusterRoleRulesServer }}
 {{- range $ns := .Values.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -8,6 +9,9 @@ metadata:
     app.kubernetes.io/name: {{ $ns }}-gitops-argocd-server
     app.kubernetes.io/part-of: {{ $ns }}
   name: {{ $ns }}-gitops-argocd-server
+{{- if $rules }}
+{{- toYaml $rules | nindent 0 }}
+{{- else }}
 rules:
 - apiGroups:
   - '*'
@@ -30,5 +34,6 @@ rules:
   - pods/log
   verbs:
   - get     # supports viewing pod logs from UI
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gitops-operator/templates/argocd-server-clusterrolebinding.yaml
+++ b/charts/gitops-operator/templates/argocd-server-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.namespaces }}
+{{- if and (.Values.namespaces) (.Values.teamInstancesAreClusterScoped) }}
 {{- range $ns := .Values.namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/gitops-operator/templates/subscription.yaml
+++ b/charts/gitops-operator/templates/subscription.yaml
@@ -16,6 +16,8 @@ spec:
     env:
     - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
       value:  {{ .Values.operator.disableDefaultArgoCD | quote }}
+{{- if and (.Values.namespaces) (.Values.teamInstancesAreClusterScoped) }}
     - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
       value: {{ join "," .Values.namespaces | quote }}
+{{- end }}
 {{- end }}

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -28,7 +28,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.2.6
+  version: v2.2.7
   rbac:
     defaultPolicy: 'role:admin'
     policy: |

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -17,6 +17,8 @@ operator:
   name: openshift-gitops-operator
   disableDefaultArgoCD: true
 
+teamInstancesAreClusterScoped: true
+
 # adding your secrets for git access or other repository credentials
 secrets: []
 # EXAMPLE ...


### PR DESCRIPTION
#### What is this PR About?
Allow more customization of the team ArgoCD RBAC via the helm chart.

1. Add a new variable `teamInstancesAreClusterScoped` - default is true. 

this is the current behaviour of the chart today. if set to false, the extra Cluster RBAC is *not* added to team instances (so they get their RBAC from the gitops-operator only and are in namespace mode).

2. Allow Cluster RBAC for team instances to be overridden.

override the Role rules by setting one or both of these:

`clusterRoleRulesController`
`clusterRoleRulesServer`

this allows fine grained control over the RBAC. the defaults remain the same see these files:

`argocd-server-clusterrole.yaml`
`argocd-application-controller-clusterrole.yaml`

these are wider (intentionally) than what the gitops-operator set as default.

#### How do we test this?
i'm working on documentation to add to this repo. current documentation is here at the moment and is a WIP:
- https://github.com/eformat/argocd-team-topologies

cc: @redhat-cop/day-in-the-life
