### PR TITLE
🦒 bump operator v1.4.5 🦒

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.3.1
+appVersion: v2.3.2
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.3.2
+version: 0.3.3
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -11,7 +11,7 @@ namespaces:
 
 # operator manages upgrades
 operator:
-  version: openshift-gitops-operator.v1.4.3
+  version: openshift-gitops-operator.v1.4.5
   channel: stable
   installPlanApproval: Automatic
   name: openshift-gitops-operator
@@ -30,7 +30,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.3.1
+  version: v2.3.2
   rbac:
     defaultPolicy: 'role:admin'
     policy: |


### PR DESCRIPTION
#### What is this PR About?
security fix release bump operator to v1.4.5 as default. skip broken 1.4.4

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
