### PR TITLE
Set annotation for helm resource policy

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitea/templates/persistentvolumeclaim.yaml
+++ b/charts/gitea/templates/persistentvolumeclaim.yaml
@@ -3,8 +3,10 @@ kind: PersistentVolumeClaim
 metadata:
   {{ template "app.labels" }}
   name: "{{ template "app.name" }}-repositories"
+{{- if .Values.pvcPolicyKeep }}
   annotations:
     "helm.sh/resource-policy": keep
+{{- end }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/charts/gitea/templates/postgresql-pvc.yaml
+++ b/charts/gitea/templates/postgresql-pvc.yaml
@@ -3,8 +3,10 @@ kind: PersistentVolumeClaim
 metadata:
   {{ template "app.labels" }}
   name: {{ .Values.db.name | default "gitea-db" | quote }}
+{{- if .Values.pvcPolicyKeep }}
   annotations:
     "helm.sh/resource-policy": keep
+{{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -15,6 +15,9 @@
 # secret_key: '8 character hard to guess alpha string'
 # internal_token: '106 character hard to guess string'
 
+# Set the `"helm.sh/resource-policy": keep` annotation on PVCs to prevent accidental deletion
+# pvcPolicyKeep: true
+
 ## YOU MUST SPECIFY THE DB PASSWORD!!!
 db: {}
 #   password: 'S00perSekretP@ssw0rd$'


### PR DESCRIPTION
Set annotation for helm resource policy so that PVCs are not ever automatically deleted

#### What is this PR About?
I was applying some updates and because there was a slight difference in the values a PVC was deleted and I had to scramble to recover. This change makes the PVCs have a helm resource policy of "keep" so that uninstalling the helm chart will not destroy data.

#### How do we test this?
1. Run `helm template test ./`
2. Check the output for the PVCs and ensure that the annotation `"helm.sh/resource-policy": keep` is present

cc: @redhat-cop/day-in-the-life
