### PR TITLE
🦅 update nexus to 3.38.1, make redhat mvn repos optional 🦅

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
-appVersion: 3.37.3
+appVersion: 3.38.1
 description: Sonatype Nexus is an open source repository manager
 home: https://github.com/redhat-cop/helm-charts
 name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
-version: 1.1.3
+version: 1.1.4
 maintainers:
   - name: eformat
   - name: ckavili

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -55,3 +55,4 @@ The following table lists the most common configurable parameters for the Nexus 
 | `npmRepository`                                  | Name of the NPM proxy repository                             | `labs-npm`                            |
 | `rawRepository`                                  | Name of the hosted raw repository                            | `labs-static`                         |
 | `persistence.storageSize`                        | Size of the generated PVC for Nexus                          | `8Gi`                                 |
+| `includeRHRepositories`                          | Include RedHat maven repositories in maven-public            | `true`                                |

--- a/charts/sonatype-nexus/templates/config-nexus.txt
+++ b/charts/sonatype-nexus/templates/config-nexus.txt
@@ -1,3 +1,23 @@
+{{- define "config-nexus-maven-central-only" }}
+# Maven Public Group
+echo "🦄 Adding repos to Maven Group"
+curl -s -k -X PUT "${NEXUS_URL}/service/rest/v1/repositories/maven/group/maven-public" \
+  --user "${NEXUS_USER}" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d "{ \"name\": \"maven-public\", \"format\": \"maven2\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true }, \"group\": { \"memberNames\": [\"maven-releases\", \"maven-snapshots\", \"maven-central\"]}, \"type\": \"group\"}"
+{{- end }}
+
+{{- define "config-nexus-maven-incl-redhat" }}
+# Maven Public Group
+echo "🦄 Adding repos to Maven Group"
+curl -s -k -X PUT "${NEXUS_URL}/service/rest/v1/repositories/maven/group/maven-public" \
+  --user "${NEXUS_USER}" \
+  -H "accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d "{ \"name\": \"maven-public\", \"format\": \"maven2\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true }, \"group\": { \"memberNames\": [\"{{ .Values.rhEaRepositories | default "red-hat-ea" }}\", \"{{ .Values.rhGaRepositories | default "red-hat-ga" }}\",\"maven-releases\", \"maven-snapshots\", \"maven-central\"]}, \"type\": \"group\"}"
+{{- end }}
+
 {{- define "config-nexus" }}
 #!/bin/bash
 
@@ -48,13 +68,12 @@ curl -s -k -X POST "${NEXUS_URL}/service/rest/v1/repositories/maven/proxy" \
   -H "Content-Type: application/json" \
   -d "{ \"name\": \"{{ .Values.rhEaRepositories | default "red-hat-ea" }}\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true }, \"cleanup\": { \"policyNames\": [ \"string\" ] }, \"proxy\": { \"remoteUrl\": \"https://maven.repository.redhat.com/earlyaccess/all\", \"contentMaxAge\": 1440, \"metadataMaxAge\": 1440 }, \"negativeCache\": { \"enabled\": true, \"timeToLive\": 1440 }, \"httpClient\": { \"blocked\": false, \"autoBlock\": true, \"connection\": { \"retries\": 0, \"userAgentSuffix\": \"string\", \"timeout\": 60, \"enableCircularRedirects\": false, \"enableCookies\": false, \"useTrustStore\": false }, \"authentication\": { \"type\": \"username\", \"username\": \"string\", \"password\": \"string\", \"ntlmHost\": \"string\", \"ntlmDomain\": \"string\", \"preemptive\": false } }, \"routingRule\": \"string\", \"maven\": { \"versionPolicy\": \"MIXED\", \"layoutPolicy\": \"STRICT\" }}"
 
-# Maven Public Group
-echo "🦄 Adding repos to Maven Group"
-curl -s -k -X PUT "${NEXUS_URL}/service/rest/v1/repositories/maven/group/maven-public" \
-  --user "${NEXUS_USER}" \
-  -H "accept: application/json" \
-  -H "Content-Type: application/json" \
-  -d "{ \"name\": \"maven-public\", \"format\": \"maven2\", \"online\": true, \"storage\": { \"blobStoreName\": \"default\", \"strictContentTypeValidation\": true }, \"group\": { \"memberNames\": [\"{{ .Values.rhEaRepositories | default "red-hat-ea" }}\", \"{{ .Values.rhGaRepositories | default "red-hat-ga" }}\",\"maven-releases\", \"maven-snapshots\", \"maven-central\"]}, \"type\": \"group\"}"
+# Optionally include RedHat Repositories in maven-public
+{{- if .Values.includeRHRepositories }}
+{{- include "config-nexus-maven-incl-redhat" . }}
+{{- else }}
+{{- include "config-nexus-maven-central-only" . }}
+{{- end }}
 
 # raw hosted via rest
 echo "🐺 creating {{ .Values.rawRepository | default "labs-static" }} raw hosted repo"
@@ -72,4 +91,4 @@ oc -n ${NS} delete pod -lapp="{{- default .Chart.Name .Values.nameOverride | tru
 oc -n ${NS} wait pod -lapp="{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}" --for=condition=Ready --timeout=300s
 
 echo "Done!"
-{{- end}}
+{{- end }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -26,6 +26,7 @@ helmRepository:
   - helm-charts
   - helm-charts-stable
   - helm-charts-incubator
+includeRHRepositories: true
 nexus:
   dockerPort: 5003
   env:
@@ -35,7 +36,7 @@ nexus:
   - name: NEXUS_SECURITY_RANDOMPASSWORD
     value: "false"
   hostAliases: []
-  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.37.3-ubi-1
+  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.38.1-ubi-1
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   livenessProbe:


### PR DESCRIPTION
#### What is this PR About?
- update nexus image to latest 3.38.1-ubi-1
- add support to optionally set maven-public without RedHat repositories (speed up first build if only maven-central needed)

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
