### PR TITLE
Allow annotations on jenkins secrets

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 1.0.7
+version: 1.0.8
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ .name }}
   labels:
     credential.sync.jenkins.openshift.io: "true"
+{{- if .annotations }}
+  annotations:
+{{- toYaml .annotations | nindent 4 }}
+{{- end}}
 type: {{ .type | default "kubernetes.io/basic-auth" | quote }}
 stringData:
   {{- if .token }}

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -10,6 +10,13 @@ source_secrets:
   - name: git-auth
     username: idm-sa
     password: thisisdefinitelymypassword
+    # annotations:
+    #   build.openshift.io/source-secret-match-uri-1: 'https://gitea.*/*'
+    #   build.openshift.io/source-secret-match-uri-2: 'http://gitea:3000/*'
+    #   build.openshift.io/source-secret-match-uri-3: 'https://gitea-helm-test-devops.apps.clms.0wuq.p1.openshiftapps.com/*'
+    #   tekton.dev/git-0: 'http://gitea.clms-devops.svc.cluster.local:3000'
+    #   tekton.dev/git-1: 'http://gitea:3000'
+    #   tekton.dev/git-2: 'https://gitea.apps.clms.0wuq.p1.openshiftapps.com'
     # some token... appears in jenkins env as JSON ie {"token": "aaaaa.bbbbb.ccccc"}
   - name: my-token
     type: Opaque


### PR DESCRIPTION
#### What is this PR About?
This extends the current Jenkins chart to allow adding arbitrary annotations to the Secrets created alongside Jenkins

#### How do we test this?
1. Uncomment the `annotations` in `charts/jenkins/values.yaml` for the first secret
1. Dry-run the chart `helm upgrade --install --dry-run clms-devsecops charts/jenkins/`
1. View the output and check that the secret has the expected annotations

cc: @redhat-cop/day-in-the-life
