### PR TITLE
[operatorhub chart] Remove startingCSV field from default values.yaml

### DIFF
--- a/charts/operatorhub/Chart.yaml
+++ b/charts/operatorhub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: operatorhub
 description: A Helm chart to create OperatorHub subscriptions
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: 1.0.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://avatars3.githubusercontent.com/u/38202270?s=280&v=4

--- a/charts/operatorhub/values.yaml
+++ b/charts/operatorhub/values.yaml
@@ -11,6 +11,5 @@ operators:
       operatorName: operator-name
       sourceName: catalog-source
       sourceNamespace: catalog-source-namespace
-      csv: optional-catalog-source-version
     operatorgroup:
       create: true


### PR DESCRIPTION
#### What is this PR About?
This PR removes startingCSV field from default values.yaml file of operatorhub chart. Having that in place was effectively making that value non-optional, forcing updates to other dependant charts.

#### How do we test this?
Apply the chart. If all hell doesn't break loose, all is fine! 

cc: @redhat-cop/day-in-the-life
