### PR TITLE
Make Starting CSV on Gitops Operator optional

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.3.4
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.3.8
+version: 0.3.9
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/templates/subscription.yaml
+++ b/charts/gitops-operator/templates/subscription.yaml
@@ -11,7 +11,9 @@ spec:
   name: {{ .Values.operator.name }}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+{{- if .Values.operator.version }}
   startingCSV: {{ .Values.operator.version | quote }}
+{{- end }}
   config:
     env:
     - name: DISABLE_DEFAULT_ARGOCD_INSTANCE

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -11,7 +11,6 @@ namespaces:
 
 # operator manages upgrades
 operator:
-  version: openshift-gitops-operator.v1.5.2
   channel: stable
   installPlanApproval: Automatic
   name: openshift-gitops-operator


### PR DESCRIPTION
#### What is this PR About?
This PR makes Starting CSV optional in Subscription object for Gitops Operator

#### How do we test this?
Run the chart:)

cc: @redhat-cop/day-in-the-life
