### PR TITLE
🦈 argocd 2.4.7, gitops 1.6.0 🦈

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.3.6
+appVersion: v2.4.7
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.3.12
+version: 0.4.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -11,14 +11,14 @@ namespaces:
 
 # operator manages upgrades
 operator:
-  channel: stable
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   sourceName: redhat-operators
   sourceNamespace: openshift-marketplace
   disableDefaultArgoCD: true
 
-
+# see the TEAM_DOCS.md for more information
 teamInstancesAreClusterScoped: true
 
 # adding your secrets for git access or other repository credentials
@@ -32,8 +32,10 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.3.6
+  version: v2.4.7
   applicationSet: {}
+  notifications:
+    enabled: true
   rbac:
     defaultPolicy: 'role:admin'
     policy: |


### PR DESCRIPTION
#### What is this PR About?
Updates to latest argocd 2.4.7, and latest channel for gitops 1.6.0

Please read - 2.4 breaking changes argocd:
https://blog.argoproj.io/breaking-changes-in-argo-cd-2-4-29e3c2ac30c9
https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/upgrading/2.3-2.4.md
https://docs.openshift.com/container-platform/4.10/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-6-0_gitops-release-notes

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
