### PR TITLE
🐉 .spec.dex is deprecated 🐉

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.4.11
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.4.3
+version: 0.4.4
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -54,8 +54,9 @@ argocd_cr:
       enabled: true
       tls:
         termination: reencrypt
-  dex:
-    openShiftOAuth: true
+  sso:
+    dex:
+      openShiftOAuth: true
 
   initialRepositories: |
     - name: ubiquitous-journey


### PR DESCRIPTION
#### What is this PR About?
`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex` so values updated to accommodate this change.

#### How do we test this?
Provide commands/steps to test this PR.

`helm install .`

cc: @redhat-cop/day-in-the-life
