### PR TITLE
🏦 UPDATE -  IPA on Infra nodes and some fixes 🏦

### DIFF
--- a/charts/ipa/Chart.yaml
+++ b/charts/ipa/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ipa
-description: A Helm chart ti install FreeIPA
-version: 1.0.3
+description: A Helm chart to install FreeIPA
+version: 1.1.0
 appVersion: 1.16.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.freeipa.org/images/freeipa/freeipa-logo-small.png

--- a/charts/ipa/README.md
+++ b/charts/ipa/README.md
@@ -1,9 +1,9 @@
 # 👨‍👩‍👦‍👦 FreeIPA Chart
 
-Installs FreeIPA server to an OpenShift cluster ready for integration with OCP Authentication. This is disabled by default but if you look at the values file you'll see how it can be configured easily. FreeIPA needs to know it's host up front along with other configurable fields for setting up the LDAP server so you must specify `app_domain` for it to work properly.
+Installs FreeIPA server to an OpenShift cluster ready for integration with OCP Authentication. This is disabled by default but if you look at the values file you'll see how it can be configured easily. FreeIPA needs to know it's host up front along with other configurable fields for setting up the LDAP server so you must specify `domain` and `sub_domain` for it to work properly.
 
 ```bash
-helm upgrade --install my . --namespace=ipa --set app_domain=apps.mycluster.example.com
+helm upgrade --install ipa . --namespace=ipa --create-namespace --set domain=example.com --set sub_domain=my.sandbox
 ```
 
 FreeIPA takes some time to configure and launch the first time so be patient - or just go off and get a 🫖, that's what i did!

--- a/charts/ipa/templates/_helpers.tpl
+++ b/charts/ipa/templates/_helpers.tpl
@@ -35,6 +35,13 @@ Create a release namespace such that helm template and install is happy
 {{- end }}
 
 
+{{- define "ipa.ldap_domain" -}}
+{{- $parts := split "." .Values.domain }}
+{{- $p0 := printf "%s=%s" "dc" $parts._0 | trunc 63 | trimSuffix "-"}}
+{{- $p1 := printf "%s=%s" "dc" $parts._1 | trunc 63 | trimSuffix "-"}}
+{{- printf "%s,%s" $p0 $p1 | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/ipa/templates/deploymentconfig.yaml
+++ b/charts/ipa/templates/deploymentconfig.yaml
@@ -21,6 +21,17 @@ spec:
       labels:
         deploymentconfig: {{ include "ipa.fullname" . }}
     spec:
+      {{- if .Values.runOnInfra }}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      - effect: NoExecute
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      {{- end }}
       volumes:
       - name: {{ include "ipa.fullname" . }}-data
         persistentVolumeClaim:
@@ -59,11 +70,11 @@ spec:
           protocol: TCP
         env:
         - name: IPA_SERVER_HOSTNAME
-          value: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.{{ .Values.app_domain }}
+          value: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.cluster_name }}.{{ .Values.domain }}
         - name: IPA_SERVER_IP
           value: ""
         - name: IPA_SERVER_INSTALL_OPTS
-          value: {{ .Values.install_opts }} {{ .Values.realm }}
+          value: {{ .Values.install_opts }} -r {{ .Values.domain }}
         - name: PASSWORD
           valueFrom:
             secretKeyRef:

--- a/charts/ipa/templates/deploymentconfig.yaml
+++ b/charts/ipa/templates/deploymentconfig.yaml
@@ -70,7 +70,7 @@ spec:
           protocol: TCP
         env:
         - name: IPA_SERVER_HOSTNAME
-          value: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.cluster_name }}.{{ .Values.domain }}
+          value: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.sub_domain }}.{{ .Values.domain }}
         - name: IPA_SERVER_IP
           value: ""
         - name: IPA_SERVER_INSTALL_OPTS

--- a/charts/ipa/templates/machineconfig.yaml
+++ b/charts/ipa/templates/machineconfig.yaml
@@ -4,7 +4,11 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
+    {{- if .Values.runOnInfra }}
+    machineconfiguration.openshift.io/role: infra
+    {{- else }}
     machineconfiguration.openshift.io/role: worker
+    {{- end }}
   name: 01-sebool
 spec:
   config:

--- a/charts/ipa/templates/route.yaml
+++ b/charts/ipa/templates/route.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     description: Route for FreeIPA server's HTTPS
 spec:
-  host: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.cluster_name }}.{{ .Values.domain }}
+  host: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.sub_domain }}.{{ .Values.domain }}
   to:
     kind: Service
     name: {{ include "ipa.fullname" . }}

--- a/charts/ipa/templates/route.yaml
+++ b/charts/ipa/templates/route.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     description: Route for FreeIPA server's HTTPS
 spec:
-  host: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.{{ .Values.app_domain }}
+  host: {{ include "ipa.fullname" . }}-{{ include "ipa.namespace" . }}.apps.{{ .Values.cluster_name }}.{{ .Values.domain }}
   to:
     kind: Service
     name: {{ include "ipa.fullname" . }}

--- a/charts/ipa/templates/setup-oauth-job.yaml
+++ b/charts/ipa/templates/setup-oauth-job.yaml
@@ -24,6 +24,11 @@ spec:
                 fi
             done
             echo "Patching OAuth LDAP ..."
+            oc get -o yaml oauth/cluster | grep identityProvider
+            if [ $? -ne 0 ]; then
+                echo "Setting the identityProviders property if missing"
+                oc patch oauth/cluster --type=json -p '[{"op":"add", "path":"/spec", "value":{"identityProviders":[]}}]'
+            fi
             oc patch oauth/cluster --type=json -p '[{"op":"add", "path":"/spec/identityProviders/-",
               "value":{"ldap": {"attributes": {"email": ["mail"], "id": ["dn"], "name": ["displayName"], "preferredUsername": ["uid"]},
               "bindDN": "{{ .Values.ocp_auth.bind_dn }},{{ include "ipa.ldap_domain" . }}", "bindPassword": {"name": "{{ include "ipa.fullname" . }}-bind-password" },

--- a/charts/ipa/templates/setup-oauth-job.yaml
+++ b/charts/ipa/templates/setup-oauth-job.yaml
@@ -26,8 +26,8 @@ spec:
             echo "Patching OAuth LDAP ..."
             oc patch oauth/cluster --type=json -p '[{"op":"add", "path":"/spec/identityProviders/-",
               "value":{"ldap": {"attributes": {"email": ["mail"], "id": ["dn"], "name": ["displayName"], "preferredUsername": ["uid"]},
-              "bindDN": {{ .Values.ocp_auth.bind_dn | quote }}, "bindPassword": {"name": "{{ include "ipa.fullname" . }}-bind-password" },
-              "insecure": true, "url": "ldap://{{ include "ipa.fullname" . }}.{{ include "ipa.namespace" . }}.svc.cluster.local:389/{{ .Values.ocp_auth.domain }}?uid?sub?(memberOf={{ .Values.ocp_auth.base }})"},
+              "bindDN": "{{ .Values.ocp_auth.bind_dn }},{{ include "ipa.ldap_domain" . }}", "bindPassword": {"name": "{{ include "ipa.fullname" . }}-bind-password" },
+              "insecure": true, "url": "ldap://{{ include "ipa.fullname" . }}.{{ include "ipa.namespace" . }}.svc.cluster.local:389/{{ include "ipa.ldap_domain" . }}?uid?sub?(memberOf={{ .Values.ocp_auth.base }},{{ include "ipa.ldap_domain" . }})"},
               "mappingMethod": "claim", "name": "FreeIPA", "type": "LDAP"}}]'
             exit 0
         image: "quay.io/openshift/origin-cli:latest"

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -2,7 +2,6 @@
 # These values will probs need to be overwritten or could use lookup function?
 # app_domain: apps.mycluster.example.com
 admin_password: Passw0rd
-# realm: "-r redhatlabs.dev"
 
 cluster_name: springdo.sandbox1422
 domain: opentlc.com

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -1,8 +1,11 @@
 # IPA Server must know it's own hostname to work properly....
 # These values will probs need to be overwritten or could use lookup function?
-app_domain: apps.mycluster.example.com
+# app_domain: apps.mycluster.example.com
 admin_password: Passw0rd
-realm: "-r redhatlabs.dev"
+# realm: "-r redhatlabs.dev"
+
+cluster_name: springdo.sandbox1422
+domain: opentlc.com
 
 # sensible defaults
 image: freeipa-server:rhel-7
@@ -18,10 +21,12 @@ volume: 5Gi
 # disabled by default so as to not overwrite existing oauth configs in openshift-config ns
 ocp_auth:
   enabled: false
-  bind_dn: "uid=admin,cn=users,cn=accounts,dc=redhatlabs,dc=dev"
+  bind_dn: "uid=admin,cn=users,cn=accounts"
   bind_password: Passw0rd
-  base: "cn=student,cn=groups,cn=accounts,dc=redhatlabs,dc=dev"
-  domain: "dc=redhatlabs,dc=dev"
+  base: "cn=student,cn=groups,cn=accounts"
 
 machineconfig:
   ignition_version: 3.1.0
+
+# assumes node-role.kubernetes.io/infra: "" on one or more nodes
+runOnInfra: false

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -1,10 +1,10 @@
 # IPA Server must know it's own hostname to work properly....
 # These values will probs need to be overwritten or could use lookup function?
-# app_domain: apps.mycluster.example.com
 admin_password: Passw0rd
 
-cluster_name: springdo.sandbox1422
-domain: opentlc.com
+# these must be set in line with whats in the cluster !!
+domain: example.com
+sub_domain: my.sandbox
 
 # sensible defaults
 image: freeipa-server:rhel-7

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -26,7 +26,7 @@ ocp_auth:
   base: "cn=student,cn=groups,cn=accounts"
 
 machineconfig:
-  ignition_version: 3.1.0
+  ignition_version: 3.2.0
 
 # assumes node-role.kubernetes.io/infra: "" on one or more nodes
 runOnInfra: false


### PR DESCRIPTION
#### What is this PR About?
Add infra node pinning to the chart and fixed up the dodgy OAuth patch thingy

#### How do we test this?
Provide commands/steps to test this PR.
In a cluster I ran `helm upgrade --install ipa ipa --set runOnInfra=true --set ocp_auth.enabled=true --set domain=opentlc.com --set sub_domain=springdo.sandbox1234` from the charts dir of this repo

cc: @redhat-cop/day-in-the-life
