### PR TITLE
Updated postgres image tag (9.6-el8 not present anymore in ocp 4.10)

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: A Helm chart for deploying Pact Broker on OpenShift 🔗
 name: pact-broker
-version: 0.0.8
+version: 0.0.9
 home: https://github.com/redhat-cop/helm-charts
 icon: https://img.stackshare.io/service/11305/pact.png
 maintainers:

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -52,7 +52,7 @@ postgresql:
     database: *name
     type: ClusterIP
   image:
-    tag: "9.6-el8"
+    tag: "10-el8"
   persistent:
     volume:
       size: "5Gi"


### PR DESCRIPTION
#### What is this PR About?
Updating the postgres image tag. In OpenShift 4.10, the imageStreamTag 9-6-el8 is not available, and therefore, the PostgreSQL pod doesn't start with the following status message: "Deployment config does not have minimum availability." by updating the image to 10-el8, the PostgreSQL DB is deployed, and the pact-broker helm chart works properly.

#### How do we test this?
In your OpenShift cluster with version 4.10 or higher, do the following:
```
cd charts/pact-broker
helm install pact-broker .
```

cc: @redhat-cop/day-in-the-life
