### PR TITLE
🌶️ argocd v2.5.4 🌶️

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.4.17
+appVersion: v2.5.4
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.4.9
+version: 0.5.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -32,7 +32,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.4.17
+  version: v2.5.4
   applicationSet: {}
   notifications:
     enabled: true


### PR DESCRIPTION
#### What is this PR About?
update to v2.5.4 argocd to match gitops-operator v1.7.0 
dex is tls enabled now (breaking change from 2.4.17)

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
