### PR TITLE
Remove hardcoded namespace on GitOps Operator

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2.5.4
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.5.1
+version: 0.5.2
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/templates/subscription.yaml
+++ b/charts/gitops-operator/templates/subscription.yaml
@@ -4,7 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: openshift-operators
+  namespace: {{ .Values.operator.namespace | default "openshift-operators" }}
 spec:
   channel: {{ .Values.operator.channel }}
   installPlanApproval: {{ .Values.operator.installPlanApproval }}


### PR DESCRIPTION
#### What is this PR About?
This PR removes hardcoded namespace to be used for GitOps Operator installation. 

#### How do we test this?
Run the chart

cc: @redhat-cop/day-in-the-life
