### PR TITLE
Accept inline splunk ca bundle

### DIFF
--- a/charts/openshift-logforwarding-splunk/Chart.yaml
+++ b/charts/openshift-logforwarding-splunk/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: openshift-logforwarding-splunk
 description: Log Forwarding from OpenShift to Splunk
-version: 0.0.2
+version: 0.0.3
 maintainers:
 - email: andy.block@gmail.com
   name: sabre1041

--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-certs-secret.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-certs-secret.yaml
@@ -1,8 +1,4 @@
-{{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.caFile -}}
-{{- $splunkCaFile := .Files.Get .Values.forwarding.splunk.caFile }}
-{{- if not $splunkCaFile -}}
-{{- fail "Could not locate Splunk Certificate" }}
-{{ end }}
+{{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.ca_bundle -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +9,5 @@ metadata:
 {{ include "openshift-logforwarding-splunk.labels" . | indent 4 }}
 type: Opaque
 data:
-    splunk-ca.crt: {{ $splunkCaFile | b64enc }}
+    splunk-ca.crt: {{ .Values.forwarding.splunk.ca_bundle | b64enc }}
 {{ end }}

--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-configmap.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-configmap.yaml
@@ -52,7 +52,7 @@ data:
       hec_port "#{ENV['SPLUNK_PORT'] }"
       hec_token "#{ENV['SPLUNK_TOKEN'] }"
       host "#{ENV['NODE_NAME']}"
-      {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.caFile }}
+      {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.ca_bundle }}
       ca_file /secret/splunk/splunk-ca.crt
       {{- end }}
       {{- with .Values.forwarding.fluentd.buffer }}

--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-statefulset.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/log-forwarding-splunk-configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/log-forwarding-splunk-secret.yaml") . | sha256sum }}
       labels:
         app: {{ $fullName }}
     spec:

--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-statefulset.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-splunk-statefulset.yaml
@@ -20,6 +20,8 @@ spec:
       app: {{ $fullName }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/log-forwarding-splunk-configmap.yaml") . | sha256sum }}
       labels:
         app: {{ $fullName }}
     spec:
@@ -105,7 +107,7 @@ spec:
             {{- end }}
             - name: buffer
               mountPath: "/var/log/fluentd"
-            {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.caFile }}
+            {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.ca_bundle }}
             - mountPath: /secret/splunk
               name: splunk-certs
               readOnly: true
@@ -175,7 +177,7 @@ spec:
         - name: buffer
           emptyDir: {}
         {{- end }}
-        {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.caFile }}
+        {{- if and (not .Values.forwarding.splunk.insecure) .Values.forwarding.splunk.ca_bundle }}
         - name: splunk-certs
           secret:
             secretName: {{ $fullName }}-splunk

--- a/charts/openshift-logforwarding-splunk/values.yaml
+++ b/charts/openshift-logforwarding-splunk/values.yaml
@@ -85,5 +85,8 @@ forwarding:
     sourcetype: openshift
     source: openshift
 
-    # Specify the CA Certificate for Splunk
-    # caFile: "files/splunk-ca.crt"
+    # Specify the custom CA bundle for Splunk
+    # ca_bundle: |
+    #    -----BEGIN CERTIFICATE-----
+    #    ...
+    #    -----END CERTIFICATE-----


### PR DESCRIPTION
#### What is this PR About?

There are two changes in this PR, both for openshift-logforwarding-splunk:

* Added a `checksum/config` annotation to the pods in the StatefulSet to make the pods restart when the ConfigMap is updated, so the new values become active in the cluster. I used [Automatically Roll Deployments](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) from the Helm docs as inspiration.
* Replaced the optional `forwarding.splunk.caFile` value with `forwarding.splunk.ca_bundle` variable. This provides the feature to keep using the published chart and specify a custom CA bundle for connecting to the Splunk heavy forwarder with a `helm install logforwarding-splunk redhat-cop/openshift-logforwarding-splunk -f override-values-with-custom-ca-bundle.yaml`. I was not able to find a way to pass a file reference when deploying a chart.

#### How do we test this?

For the annotation:
* Deploy the chart
* Change a value that is specified in the ConfigMap. For example, switch `forwarding.splunk.insecure` to false.
* Upgrade the helm chart
* Note the pods in the StatefulSet restarting with the changed configuration

For the custom ca bundle:
* Given a Splunk heavy forwarder with self-signed certificate or one from a custom CA 
* Add a values file and specify a custom ca bundle
* Install helm chart with the custom value file
* Note the connection to the heavy forwarder being established without SSL validation errors 

cc: @redhat-cop/day-in-the-life
