### PR TITLE
Gitea: Misc fixes, allow custom IS for postgresql…

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitea/templates/configmap.yaml
+++ b/charts/gitea/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
     ROOT = /gitea-repositories
 
     [server]
-    ROOT_URL         = https://{{ required "You MUST specify the public-facing hostname" .Values.hostname }}/
+    ROOT_URL         = https://{{ required "You MUST specify the external hostname to be used for the public-facing web page" .Values.hostname }}/
     SSH_DOMAIN       = {{ .Values.hostname }}
     DOMAIN           = {{ .Values.hostname }}
     HTTP_PORT        = 3000

--- a/charts/gitea/templates/imagestream.yaml
+++ b/charts/gitea/templates/imagestream.yaml
@@ -2,7 +2,7 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   {{ template "app.labels" }}
-  name: gitea
+  name: {{ .Values.imagestream_name | default "gitea" | quote }}
 spec:
   lookupPolicy:
     local: false
@@ -14,6 +14,6 @@ spec:
       name: {{ .Values.imagestream_from | default "quay.io/gpte-devops-automation/gitea:latest" | quote }}
     generation: 2
     importPolicy: {}
-    name: latest
+    name: {{ .Values.imagestream_tag | default "latest" | quote }}
     referencePolicy:
       type: Local

--- a/charts/gitea/templates/persistentvolumeclaim.yaml
+++ b/charts/gitea/templates/persistentvolumeclaim.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   {{ template "app.labels" }}
-  name: "{{ template "app.name" }}-repositories"
+  name: "{{ .Release.Name | default "gitea" }}-repositories"
 {{- if .Values.pvcPolicyKeep }}
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/gitea/templates/postgresql-is.yaml
+++ b/charts/gitea/templates/postgresql-is.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.db.imagestream_from }}
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  {{ template "app.labels" }}
+  name: {{ .Values.db.imagestream_name | default "postgresql" | quote }}
+  namespace: {{ .Values.db.imagestream_namespace | default "openshift" | quote }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      openshift.io/imported-from: {{ .Values.db.imagestream_from | quote }}
+    from:
+      kind: DockerImage
+      name: {{ .Values.db.imagestream_from | quote }}
+    generation: 2
+    importPolicy: {}
+    name: {{ .Values.db.imagestream_tag | default "latest" | quote }}
+    referencePolicy:
+      type: Local
+{{- end }}

--- a/charts/gitea/templates/route.yaml
+++ b/charts/gitea/templates/route.yaml
@@ -2,11 +2,15 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   annotations:
-    description: Gitea's HTTP route
+    description: Gitea's route
   {{ template "app.labels" }}
   name: {{ template "app.name" }}
 spec:
   host: {{ required "You MUST specify the external hostname to be used for the public-facing web page" .Values.hostname }}
+{{- if .Values.tlsRoute }}
+  tls:
+    termination: edge
+{{- end }}
   to:
     kind: Service
     name: {{ template "app.name" }}

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -10,7 +10,7 @@
 # imagestream_name: gitea
 # imagestring_tag: latest
 
-# repository_size: 1Gi
+# repository_size: 5Gi
 
 # secret_key: '8 character hard to guess alpha string'
 # internal_token: '106 character hard to guess string'
@@ -18,11 +18,21 @@
 # Set the `"helm.sh/resource-policy": keep` annotation on PVCs to prevent accidental deletion
 # pvcPolicyKeep: true
 
+# Use edge termination for the gitea route
+tlsRoute: true
+
+
 ## YOU MUST SPECIFY THE DB PASSWORD!!!
 db: {}
 #   password: 'S00perSekretP@ssw0rd$'
 #   name: gitea-db
 #   user: gitea
+#   size: 1Gi
 #   imagestream_name: postgresql
 #   imagestream_namespace: openshift
 #   imagestream_tag: latest
+#
+## Create an ImageStream to override  where the postgresql container is pulled from, for disconnected clusters which
+## for disconnected clusters which lack the default ImageStreams. Note that the value has to be indented under db:
+## (recommended to also change imagestream_name)
+#   imagestream_from: ""


### PR DESCRIPTION
#### What is this PR About?
- Feature: Add optional ImageStream creation for the postgresql image: The default IS's are usually missing in disconnected clusters.
- Feature: Add value which enables edge TLS termination on the route (defaults to true).
- Fix: Make the `imagestream_tag` actually override the tag in the created IS for gitea.
- Fix: Name of PVC created was wrong, and breaks the deploy, if the release name is not `gitea`.
- Fix: Alter a couple of the commented-out entries in `values.yaml` to reflect what defaults the code applies.
- Fix: Make the message that flags the hostname as a required value consistent in both places where it can be generated.

#### How do we test this?
- Deploy chart with a custom release name.
- Verify the route is HTTPS with the cluster's default certificate.
- Ensure a new ImageStream is made/used for postgresql when `.Values.db.imagestream_from` is set to `registry.redhat.io/rhel8/postgresql-13:latest` and `.Values.db.imagestream_name` is set to a value such as `postgres-custom`

cc: @redhat-cop/day-in-the-life
