### PR TITLE
🎱 argocd v2.6.6 🎱

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.5.12
+appVersion: v2.6.6
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.5.7
+version: 0.6.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -32,7 +32,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.5.12
+  version: v2.6.6
   applicationSet: {}
   notifications:
     enabled: true
@@ -54,8 +54,10 @@ argocd_cr:
       enabled: true
       tls:
         termination: reencrypt
-  dex:
-    openShiftOAuth: true
+  sso:
+    dex:
+      openShiftOAuth: true
+    provider: dex
 
   initialRepositories: |
     - name: ubiquitous-journey


### PR DESCRIPTION
#### What is this PR About?
-  align to new argocd v2.6.6
- see release notes:
https://docs.openshift.com/container-platform/4.12/cicd/gitops/gitops-release-notes.html
https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.5-2.6/
- sso.dex is new in config and required
- plugin config via sidecar mandatory delayed till 2.7

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
