### PR TITLE
Add custom labels to ClusterLogForwarder in openshift-logforwarding-splunk

### DIFF
--- a/charts/openshift-logforwarding-splunk/Chart.yaml
+++ b/charts/openshift-logforwarding-splunk/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: openshift-logforwarding-splunk
 description: Log Forwarding from OpenShift to Splunk
-version: 0.0.3
+version: 0.0.4
 maintainers:
-- email: andy.block@gmail.com
-  name: sabre1041
+  - email: andy.block@gmail.com
+    name: sabre1041
 home: https://github.com/redhat-cop/helm-charts

--- a/charts/openshift-logforwarding-splunk/templates/log-forwarding-instance.yaml
+++ b/charts/openshift-logforwarding-splunk/templates/log-forwarding-instance.yaml
@@ -21,6 +21,10 @@ spec:
       {{- if or .Values.openshift.forwarding.app.elasticsearch .Values.openshift.forwarding.app.splunk }}
     - inputRefs:
         - application
+      {{- if .Values.openshift.forwarding.app.labels }}
+      labels:
+        {{- toYaml .Values.openshift.forwarding.app.labels | nindent 8 }}
+      {{- end }}
       name: container-logs
       outputRefs:
       {{- if or .Values.openshift.forwarding.app.elasticsearch }}
@@ -33,6 +37,10 @@ spec:
       {{- if or .Values.openshift.forwarding.infra.elasticsearch .Values.openshift.forwarding.infra.splunk }}
     - inputRefs:
         - infrastructure
+      {{- if .Values.openshift.forwarding.infra.labels }}
+      labels:
+        {{- toYaml .Values.openshift.forwarding.infra.labels | nindent 8 }}
+      {{- end }}
       name: infra-logs
       outputRefs:
       {{- if or .Values.openshift.forwarding.infra.elasticsearch }}
@@ -45,6 +53,10 @@ spec:
       {{- if or .Values.openshift.forwarding.audit.elasticsearch .Values.openshift.forwarding.audit.splunk }}
     - inputRefs:
         - audit
+      {{- if .Values.openshift.forwarding.audit.labels }}
+      labels:
+        {{- toYaml .Values.openshift.forwarding.audit.labels | nindent 8 }}
+      {{- end }}
       name: audit-logs
       outputRefs:
       {{- if or .Values.openshift.forwarding.audit.elasticsearch }}

--- a/charts/openshift-logforwarding-splunk/values.yaml
+++ b/charts/openshift-logforwarding-splunk/values.yaml
@@ -67,19 +67,19 @@ forwarding:
       overflow_action: block
       retry_max_times: 3
       total_limit_size: 600m
-  # Example configuration to support file based buffering
-  # "@type": file
-  # path: /var/log/fluentd/fluentd-buffers/buffer
-  # flush_mode: interval
-  # retry_type: exponential_backoff
-  # flush_thread_count: 2
-  # flush_interval: "5s"
-  # retry_forever:
-  # retry_max_interval: 30
-  # chunk_limit_size: "200m"
-  # total_limit_size: "600m"
-  # chunk_limit_records: 100000
-  # overflow_action: block
+      # Example configuration to support file based buffering
+      # "@type": file
+      # path: /var/log/fluentd/fluentd-buffers/buffer
+      # flush_mode: interval
+      # retry_type: exponential_backoff
+      # flush_thread_count: 2
+      # flush_interval: "5s"
+      # retry_forever:
+      # retry_max_interval: 30
+      # chunk_limit_size: "200m"
+      # total_limit_size: "600m"
+      # chunk_limit_records: 100000
+      # overflow_action: block
   splunk:
     # Specify Splunk HEC Token and Index
     token:

--- a/charts/openshift-logforwarding-splunk/values.yaml
+++ b/charts/openshift-logforwarding-splunk/values.yaml
@@ -7,12 +7,18 @@ openshift:
     audit:
       elasticsearch: false
       splunk: false
+      # labels:
+      #   key: audit
     app:
       elasticsearch: true
       splunk: true
+      # labels:
+      #   key: app
     infra:
       elasticsearch: true
       splunk: true
+      # labels:
+      #   key: infra
   # kubeVersion: v1.20
 
 forwarding:
@@ -62,18 +68,18 @@ forwarding:
       retry_max_times: 3
       total_limit_size: 600m
   # Example configuration to support file based buffering
-      # "@type": file
-      # path: /var/log/fluentd/fluentd-buffers/buffer
-      # flush_mode: interval
-      # retry_type: exponential_backoff
-      # flush_thread_count: 2
-      # flush_interval: "5s"
-      # retry_forever:
-      # retry_max_interval: 30
-      # chunk_limit_size: "200m"
-      # total_limit_size: "600m"
-      # chunk_limit_records: 100000
-      # overflow_action: block
+  # "@type": file
+  # path: /var/log/fluentd/fluentd-buffers/buffer
+  # flush_mode: interval
+  # retry_type: exponential_backoff
+  # flush_thread_count: 2
+  # flush_interval: "5s"
+  # retry_forever:
+  # retry_max_interval: 30
+  # chunk_limit_size: "200m"
+  # total_limit_size: "600m"
+  # chunk_limit_records: 100000
+  # overflow_action: block
   splunk:
     # Specify Splunk HEC Token and Index
     token:


### PR DESCRIPTION
#### What is this PR About?
This PR adds custom labels to the `pipelines` in the ClusterLogForwarder. The feature itself is described on https://docs.openshift.com/container-platform/4.11/logging/cluster-logging-external.html#cluster-logging-collector-log-forwarding-about_cluster-logging-external under `pipelines`. This would enable administrators to add (for example) the cluster name when forwarding logs from multiple clusters into one external logging store. 

This feature can be used by setting the labels in a custom `values.yaml` file. Default behavior has not been changed.

#### How do we test this?
* `helm install` the chart, with a custom values file that sets `openshift.forwarding.[audit|app|infra].labels`.
* after installation, observe `oc get clusterlogforwarder instance -n openshift-logging -o yaml` to see the labels applied to the pipelines.

cc: @redhat-cop/day-in-the-life
