### PR TITLE
🦆 stackrox central install retry 🦆

### DIFF
--- a/charts/stackrox/Chart.yaml
+++ b/charts/stackrox/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: stackrox-chart
 description: Install and Configure Stackrox
 type: application
-version: 0.0.7
+version: 0.0.8
 home: https://github.com/redhat-cop/helm-charts
 icon: https://avatars.githubusercontent.com/u/40638982?s=200&v=4
 maintainers:

--- a/charts/stackrox/templates/configure-stackrox-job.yaml
+++ b/charts/stackrox/templates/configure-stackrox-job.yaml
@@ -30,38 +30,53 @@ spec:
               fi
 
               # install central first
-              cat <<EOF | oc apply -f-
-              apiVersion: platform.stackrox.io/v1alpha1
-              kind: Central
-              metadata:
-                namespace: {{ .Values.stackrox.namespace | quote }}
-                name: stackrox-central-services
-              spec:
-                central:
-                  exposure:
-                    loadBalancer:
-                      enabled: false
-                      port: 443
-                    nodePort:
-                      enabled: false
-                    route:
-                      enabled: true
-                  persistence:
-                    persistentVolumeClaim:
-                      claimName: stackrox-db
-                egress:
-                  connectivityPolicy: Online
-                scanner:
-                  analyzer:
-                    resources: 
-                    {{- toYaml .Values.stackrox.analyzer.resources | nindent 22 }}
-                    scaling:
-                      autoScaling: Enabled
-                      maxReplicas: 5
-                      minReplicas: 2
-                      replicas: 3
-                  scannerComponent: Enabled
+              install_central() {
+                cat <<EOF | oc apply -f-
+                apiVersion: platform.stackrox.io/v1alpha1
+                kind: Central
+                metadata:
+                    namespace: {{ .Values.stackrox.namespace | quote }}
+                    name: stackrox-central-services
+                spec:
+                    central:
+                      exposure:
+                        loadBalancer:
+                          enabled: false
+                          port: 443
+                        nodePort:
+                          enabled: false
+                        route:
+                          enabled: true
+                      persistence:
+                        persistentVolumeClaim:
+                          claimName: stackrox-db
+                    egress:
+                      connectivityPolicy: Online
+                    scanner:
+                      analyzer:
+                        resources:
+                        {{- toYaml .Values.stackrox.analyzer.resources | nindent 24 }}
+                        scaling:
+                          autoScaling: Enabled
+                          maxReplicas: 5
+                          minReplicas: 2
+                          replicas: 3
+                      scannerComponent: Enabled
               EOF
+              }
+
+              install_central
+              until [ "$?" == 0 ]
+              do
+                  echo -e "Waiting for 0 rc from oc commands - central install"
+                  ((i=i+1))
+                  if [ $i -gt 5 ]; then
+                      echo -e "Failed - oc central install never ready?"
+                      exit 1
+                  fi
+                  sleep 5
+                  install_central
+              done
 
               # wait for central
               echo "waiting for stackrox-central ..."


### PR DESCRIPTION
#### What is this PR About?
Can occasionally get a timeout for the configure job when trying to install central e.g.

```
configure-stackrox-mnvcl configure-stackrox Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "vcentral.kb.io": failed to call webhook: Post "https://rhacs-operator-controller-manager-service.openshift-operators.svc:443/validate-platform-stackrox-io-v1alpha1-central?timeout=10s": no endpoints available for service "rhacs-operator-controller-manager-service"
``` 

Add a retry for central install.

#### How do we test this?
helm install 

cc: @redhat-cop/day-in-the-life
