### PR TITLE
operators-installer - init add

### DIFF
--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -240,3 +240,13 @@ setup_file() {
   [ "$status" -eq 0 ]
 }
 
+@test "charts/operators-installer" {
+  tmp=$(helm_template "charts/operators-installer" "-f charts/operators-installer/test-install-old-operator-values.yaml")
+
+  namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
+  cmd="conftest test ${tmp} --output tap ${namespaces}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 0 ]
+}

--- a/charts/operators-installer/.helmignore
+++ b/charts/operators-installer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: operators-installer
+description: Installs a given list of operators either using Automatic or Manual InstallPlans. If Manual then version of operator can be controlled declarativly.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+home: https://github.com/redhat-cop/helm-charts
+
+icon: https://raw.githubusercontent.com/operator-framework/olm-docs/ea9cd734aa7a6bf2d24f273322ed9aec3ffcb02a/content/en/images/logo-sm.svg
+
+keywords:
+- olm
+- operators
+
+maintainers:
+- name: itewk

--- a/charts/operators-installer/README.md
+++ b/charts/operators-installer/README.md
@@ -1,0 +1,79 @@
+# operators-installer
+
+Installs a given list of operators either using Automatic or Manual InstallPlans. If Manual then version of operator can be controlled declarativly.
+
+## Purpose
+
+There is no native way to declarativly control the version of installed operators. If you set to Automatic, then operators will auto upgrade, breaking declraative, if set to Manual then human has to go manaully approve. This helm chart allows for setting to Manual but having the helm chart automatically approve the correct InstallPlan for the specific version, so as not to accidently approve a newer InstallPlan.
+
+## Configuration
+
+For all of the Subscription parameters see
+
+| Parameter                                    | Default Value | Required? | Description
+|----------------------------------------------|---------------|-----------|------------
+| operators[].channel                          |               | Yes       | [Subscription](https://docs.openshift.com/container-platform/4latest/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1) channel.
+| operators[].installPlanApproval              |               | Yes       | [Subscription](https://docs.openshift.com/container-platform/4latest/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1) installPlanApproval.
+| operators[].name                             |               | Yes       | [Subscription](https://docs.openshift.com/container-platform/4latest/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1) name.
+| operators[].source                           |               | Yes       | [Subscription](https://docs.openshift.com/container-platform/4latest/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1) source.
+| operators[].sourceNamespace                  |               | Yes       | [Subscription](https://docs.openshift.com/container-platform/4latest/rest_api/operatorhub_apis/subscription-operators-coreos-com-v1alpha1) sourceNamespace.
+| operators[].csv                                      |               | Yes       | The CSV to install.
+| operators[].installPlanVerifierRetries       | `10`          | No        | Number of times to check if the InstallPlan has actually been installed. This may need to increase of an operator takes a long time to install.
+| operators[].installPlanVerifierActiveDeadlineSeconds | `120` | No        | Total amount of time that can be spent waiting for InstallPlan to finish installing. This may need to increase of an operator takes a long time to install.
+| installPlanApproverAndVerifyJobsImage        | `registry.redhat.io/openshift4/ose-cli:v4.10` | Yes | Image to use for the InstallPlan Approver and Verify Jobs 
+| createOperatorGroup                          | `false`       | No        | Whether or not to create an OperatorGroup in the target release namespace
+
+## Cavieats
+
+### ArgoCD / Red Hat OpenShift GitOps
+If using this helm chart with ArgoCD / Red Hat OpenShift GitOps then you will need to patch how ArgoCD does health checks on Subscriptions by default
+because the default health check will fail if there is any pending installations which is a problem for two reasons. First the approval is a post hook
+(which technically it could be made an install hook, if not for reason two), secondly if installing an older version fo an operator the Subscription will
+report there is a pending update, even though you dont wan't to update, and ArgoCD will constently say the Subscription is pending.
+
+Here is a sample updated health check to use which if the InstallPlan is set to Manual then will ignore pending plan approvals with a detailed message. How you patch ArgoCD with this health check depends on your version of ArgoCD so see the docs for your version.
+
+```lua
+health_status = {}
+if obj.status ~= nil then
+    if obj.status.conditions ~= nil then
+    numDegraded = 0
+    numPending = 0
+    msg = ""
+    for i, condition in pairs(obj.status.conditions) do
+        msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. "\n"
+        if condition.type == "InstallPlanPending" and condition.status == "True" then
+        numPending = numPending + 1
+        elseif (condition.type == "InstallPlanMissing" and condition.reason ~= "ReferencedInstallPlanNotFound") then
+        numDegraded = numDegraded + 1
+        elseif (condition.type == "CatalogSourcesUnhealthy" or condition.type == "InstallPlanFailed" or condition.type == "ResolutionFailed") and condition.status == "True" then
+        numDegraded = numDegraded + 1
+        end
+    end
+    if numDegraded == 0 and numPending == 0 then
+        health_status.status = "Healthy"
+        health_status.message = msg
+        return health_status
+    elseif numPending > 0 and numDegraded == 0 and obj.spec.installPlanApproval == "Manual" then
+        health_status.status = "Healthy"
+        health_status.message = "An install plan for a subscription is pending installation but install plan approval is set to manual so considering this as healthy: " .. msg
+        return health_status
+    elseif numPending > 0 and numDegraded == 0 then
+        health_status.status = "Progressing"
+        health_status.message = "An install plan for a subscription is pending installation - ian was here 1"
+        return health_status
+    else
+        health_status.status = "Degraded"
+        health_status.message = msg
+        return health_status
+    end
+    end
+end
+health_status.status = "Progressing"
+health_status.message = "An install plan for a subscription is pending installation - ian was here 2"
+return health_status
+```
+
+### Rollbacks
+
+This operator can not currently role operator versions back. PRs welcome.

--- a/charts/operators-installer/templates/Job_installplan-approver.yml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yml
@@ -1,0 +1,90 @@
+{{- range .Values.operators }}
+{{- if eq .installPlanApproval "Manual" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: installplan-approver--{{ .name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  backoffLimit: 5
+  parallelism: 1
+  activeDeadlineSeconds: 30
+  template:
+    spec:
+      containers:
+      - name: installplan-approver
+        image: {{ $.Values.installPlanApproverAndVerifyJobsImage }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            export HOME=/tmp/approver
+
+            echo
+            echo "Get Subscription (${SUBSCRIPTION}) UID"
+            subscriptionUID=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
+            echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
+            if [ ! -z "subscriptionUID" ]; then
+              # this complicated go-template finds an InstallPlan where both the .spec.clusterServiceVersionNames contains the expected CSV
+              # and .metadata.ownerReferences contains the expected Subscription owner. JsonPath doesn't let you do and statements and go-templates
+              # dont seem to have a funciton for checking if a value is in an array without iterating. so here we are.
+              # NOTE: this is nested in {{` `}} so that helm doesnt try to interpriate the go template
+              {{`installPlanGoTemplate=$(cat << EOF
+              {{- range .items -}}
+                {{- \$installPlanItem := . -}}
+                {{- range .spec.clusterServiceVersionNames -}}
+                  {{- if eq . "${SUBSCRIPTION_CSV}" -}}
+                    {{- range \$installPlanItem.metadata.ownerReferences -}}
+                      {{- if eq .uid "${subscriptionUID}" -}}
+                        {{\$installPlanItem.metadata.name}}
+                      {{- end -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            EOF
+              )`}}
+
+              echo
+              echo "Get InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner"
+              installPlan=$(oc get installplan -o=go-template="${installPlanGoTemplate}")
+              echo "InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner: ${installPlan}"
+              if [ ! -z "${installPlan}" ]; then
+                echo
+                echo "Check InstallPlan (${installPlan}) approval"
+                installPlanApproved=$(oc get installplan ${installPlan} -o=jsonpath="{.spec.approved}")
+                if [ "${installPlanApproved}" == "false" ]; then
+                  echo "Approving InstallPlan (${installPlan})"
+                  oc patch installplan ${installPlan} --type=json -p='[{"op":"replace","path": "/spec/approved", "value": true}]'
+                else
+                  echo "InstallPlan (${installPlan})already approved"
+                fi
+                exit 0
+              else
+                echo
+                echo "Could not find InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner. This can happen if InstallPlan isn't created yet. Try again."
+                exit 1
+              fi
+            else
+              echo
+              echo "Failed to get Subscription ($SUBSCRIPTION) UID. This really shouldn't happen."
+              exit 1
+            fi
+        imagePullPolicy: Always
+        env:
+        - name: SUBSCRIPTION_CSV
+          value: {{ .csv }}
+        - name: SUBSCRIPTION
+          value: {{ .name }}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      serviceAccount: installplan-approver
+      serviceAccountName: installplan-approver
+      terminationGracePeriodSeconds: 30
+{{- end }}
+{{- end }}

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yml
@@ -1,0 +1,90 @@
+{{- range .Values.operators }}
+{{- if eq .installPlanApproval "Manual" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: installplan-complete-verifier--{{ .name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "10"
+spec:
+  completions: 1
+  backoffLimit: {{ .installPlanVerifierRetries | default 10 }}
+  parallelism: 1
+  activeDeadlineSeconds: {{ .installPlanVerifierActiveDeadlineSeconds | default 120 }}
+  template:
+    spec:
+      containers:
+      - name: installplan-complete-verifier
+        image: {{ $.Values.installPlanApproverAndVerifyJobsImage }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            export HOME=/tmp/approver
+
+            echo
+            echo "Get Subscription (${SUBSCRIPTION}) UID"
+            subscriptionUID=$(oc get subscriptions.operators.coreos.com --field-selector metadata.name=${SUBSCRIPTION} -o=jsonpath="{.items[0].metadata.uid}")
+            echo "Subscription (${SUBSCRIPTION}) UID: ${subscriptionUID}"
+            if [ ! -z "subscriptionUID" ]; then
+              # this complicated go-template finds an InstallPlan where both the .spec.clusterServiceVersionNames contains the expected CSV
+              # and .metadata.ownerReferences contains the expected Subscription owner. JsonPath doesn't let you do and statements and go-templates
+              # dont seem to have a funciton for checking if a value is in an array without iterating. so here we are.
+              # NOTE: this is nested in {{` `}} so that helm doesnt try to interpriate the go template
+              {{`installPlanGoTemplate=$(cat << EOF
+              {{- range .items -}}
+                {{- \$installPlanItem := . -}}
+                {{- range .spec.clusterServiceVersionNames -}}
+                  {{- if eq . "${SUBSCRIPTION_CSV}" -}}
+                    {{- range \$installPlanItem.metadata.ownerReferences -}}
+                      {{- if eq .uid "${subscriptionUID}" -}}
+                        {{\$installPlanItem.metadata.name}}
+                      {{- end -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            EOF
+              )`}}
+
+              echo
+              echo "Get InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner"
+              installPlan=$(oc get installplan -o=go-template="${installPlanGoTemplate}")
+              echo "InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner: ${installPlan}"
+              if [ ! -z "${installPlan}" ]; then
+                echo
+                echo "Check InstallPlan (${installPlan}) phase"
+                installPlanPhase=$(oc get installplan ${installPlan} -o=jsonpath="{.status.phase}")
+                if [ "${installPlanPhase}" == "Complete" ]; then
+                  echo "InstallPlan (${installPlan}) complete"
+                  exit 0
+                else
+                  echo "InstallPlan (${installPlan}) not yet complete: ${installPlanPhase}"
+                  exit 1
+                fi
+              else
+                echo
+                echo "Could not find InstallPlan for CSV (${SUBSCRIPTION_CSV}) with Subscription (${SUBSCRIPTION_CSV}) (${subscriptionUID}) owner. This can happen if InstallPlan isn't created yet. Try again."
+                exit 1
+              fi
+            else
+              echo
+              echo "Failed to get Subscription ($SUBSCRIPTION) UID. This really shouldn't happen."
+              exit 1
+            fi
+        imagePullPolicy: Always
+        env:
+        - name: SUBSCRIPTION_CSV
+          value: {{ .csv }}
+        - name: SUBSCRIPTION
+          value: {{ .name }}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      serviceAccount: installplan-approver
+      serviceAccountName: installplan-approver
+      terminationGracePeriodSeconds: 30
+{{- end }}
+{{- end }}

--- a/charts/operators-installer/templates/OperatorGroup.yml
+++ b/charts/operators-installer/templates/OperatorGroup.yml
@@ -1,0 +1,10 @@
+
+{{- if .Values.createOperatorGroup }}
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: my-group
+spec:
+  targetNamespaces:
+  - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/operators-installer/templates/RoleBinding_installplan-approvers.yml
+++ b/charts/operators-installer/templates/RoleBinding_installplan-approvers.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: installplan-approvers
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: installplan-approver
+subjects:
+  - kind: ServiceAccount
+    name: installplan-approver

--- a/charts/operators-installer/templates/Role_installplan-approver.yml
+++ b/charts/operators-installer/templates/Role_installplan-approver.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: installplan-approver
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - patch

--- a/charts/operators-installer/templates/ServiceAccount_installplan-approver.yml
+++ b/charts/operators-installer/templates/ServiceAccount_installplan-approver.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: installplan-approver
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"

--- a/charts/operators-installer/templates/Subscription.yml
+++ b/charts/operators-installer/templates/Subscription.yml
@@ -1,0 +1,14 @@
+{{- range .Values.operators }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .name }}
+spec:
+  channel: {{ .channel }}
+  installPlanApproval: {{ .installPlanApproval }}
+  name: {{ .name }}
+  source: {{ .source }}
+  sourceNamespace: {{ .sourceNamespace }}
+  startingCSV: {{ .csv }}
+{{- end }}

--- a/charts/operators-installer/templates/_helpers.tpl
+++ b/charts/operators-installer/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "olm-operators-installer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "olm-operators-installer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "olm-operators-installer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "olm-operators-installer.labels" -}}
+helm.sh/chart: {{ include "olm-operators-installer.chart" . }}
+{{ include "olm-operators-installer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "olm-operators-installer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "olm-operators-installer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "olm-operators-installer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "olm-operators-installer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/operators-installer/test-install-old-operator-values.yaml
+++ b/charts/operators-installer/test-install-old-operator-values.yaml
@@ -1,0 +1,7 @@
+operators:
+- channel: stable
+  installPlanApproval: Manual
+  name: external-secrets-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  csv: external-secrets-operator.v0.8.1

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -1,0 +1,14 @@
+# Image to use for the InstallPlan Approver and Verify Jobs
+installPlanApproverAndVerifyJobsImage: registry.redhat.io/openshift4/ose-cli:v4.10
+
+# Whether or not to create an OperatorGroup in the target release namespace
+createOperatorGroup: false
+
+# EXAMPLE: declarativly controlled operator version
+operators:
+# - channel: stable
+#   installPlanApproval: Manual
+#   name: external-secrets-operator
+#   source: community-operators
+#   sourceNamespace: openshift-marketplace
+#   csv: external-secrets-operator.v0.8.2


### PR DESCRIPTION
#### What is this PR About?
Adds `operators-installer` helm chart which allows for declarative control of managing operator versions.

#### How do we test this?
Target the helm chart against a running OCP cluster.

I suggest testing with the following configs:

First
```yaml
operators:
- channel: stable
  installPlanApproval: Manual
  name: external-secrets-operator
  source: community-operators
  sourceNamespace: openshift-marketplace
  csv: external-secrets-operator.v0.8.2
```

Then:
```yaml
operators:
- channel: stable
  installPlanApproval: Manual
  name: external-secrets-operator
  source: community-operators
  sourceNamespace: openshift-marketplace
  csv: external-secrets-operator.v0.8.3
```
