### PR TITLE
operators-installer - add default labels to all resources as well as new parameter 'commonLabels' which allows user to specify addtional labels

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/README.md
+++ b/charts/operators-installer/README.md
@@ -22,6 +22,7 @@ For all of the Subscription parameters see
 | operators[].installPlanVerifierActiveDeadlineSeconds | `120` | No        | Total amount of time that can be spent waiting for InstallPlan to finish installing. This may need to increase of an operator takes a long time to install.
 | installPlanApproverAndVerifyJobsImage        | `registry.redhat.io/openshift4/ose-cli:v4.10` | Yes | Image to use for the InstallPlan Approver and Verify Jobs 
 | createOperatorGroup                          | `false`       | No        | Whether or not to create an OperatorGroup in the target release namespace
+| commonLabels                                 | `{}`          | No        | Common labels to add to all chart created resources. Implements the same idea from Kustomize for this chart.
 
 ## Cavieats
 

--- a/charts/operators-installer/templates/Job_installplan-approver.yml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yml
@@ -5,6 +5,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: installplan-approver--{{ .name }}
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yml
@@ -5,6 +5,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: installplan-complete-verifier--{{ .name }}
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/operators-installer/templates/OperatorGroup.yml
+++ b/charts/operators-installer/templates/OperatorGroup.yml
@@ -3,7 +3,9 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: my-group
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
 spec:
   targetNamespaces:
   - {{ .Release.Namespace }}

--- a/charts/operators-installer/templates/RoleBinding_installplan-approvers.yml
+++ b/charts/operators-installer/templates/RoleBinding_installplan-approvers.yml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: installplan-approvers
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/operators-installer/templates/Role_installplan-approver.yml
+++ b/charts/operators-installer/templates/Role_installplan-approver.yml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: installplan-approver
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/operators-installer/templates/ServiceAccount_installplan-approver.yml
+++ b/charts/operators-installer/templates/ServiceAccount_installplan-approver.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: installplan-approver
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/operators-installer/templates/Subscription.yml
+++ b/charts/operators-installer/templates/Subscription.yml
@@ -4,6 +4,8 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: {{ .name }}
+  labels:
+    {{- include "operators-installer.labels" $ | nindent 4 }}
 spec:
   channel: {{ .channel }}
   installPlanApproval: {{ .installPlanApproval }}

--- a/charts/operators-installer/templates/_helpers.tpl
+++ b/charts/operators-installer/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "olm-operators-installer.name" -}}
+{{- define "operators-installer.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "olm-operators-installer.fullname" -}}
+{{- define "operators-installer.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,37 +26,29 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "olm-operators-installer.chart" -}}
+{{- define "operators-installer.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "olm-operators-installer.labels" -}}
-helm.sh/chart: {{ include "olm-operators-installer.chart" . }}
-{{ include "olm-operators-installer.selectorLabels" . }}
+{{- define "operators-installer.labels" -}}
+helm.sh/chart: {{ include "operators-installer.chart" . }}
+{{ include "operators-installer.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ .Values.commonLabels | toYaml }}
+{{- end }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "olm-operators-installer.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "olm-operators-installer.name" . }}
+{{- define "operators-installer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "operators-installer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "olm-operators-installer.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "olm-operators-installer.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/charts/operators-installer/test-install-old-operator-values.yaml
+++ b/charts/operators-installer/test-install-old-operator-values.yaml
@@ -5,3 +5,6 @@ operators:
   source: community-operators
   sourceNamespace: openshift-marketplace
   csv: external-secrets-operator.v0.8.1
+
+commonLabels:
+  test-label: xyz123

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -12,3 +12,7 @@ operators:
 #   source: community-operators
 #   sourceNamespace: openshift-marketplace
 #   csv: external-secrets-operator.v0.8.2
+
+# Common labels to add to all chart created resources.
+# Implements the same idea from Kustomize for this chart.
+commonLabels:


### PR DESCRIPTION
#### What is this PR About?
operators-installer
* add default helm labels to all resources
* add `commonLabels` parameter to allow user specified labels

#### How do we test this?
1. `helm template foo ./charts/operators-installer -f charts/operators-installer/test-install-old-operator-values.yaml --namespace=ian-test --create-namespace | less`
2. veriy the output contains the custom label `test-label: xyz123` on all resources

cc: @redhat-cop/day-in-the-life
