### PR TITLE
operators-installer - protect against job names that are to long

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.3
+version: 2.3.4
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
+++ b/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
@@ -1,0 +1,19 @@
+approveManualInstallPlanViaHook: false
+
+installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.12
+
+operatorGroups:
+- name: costmanagement-metrics-operator
+  createNamespace: true
+  targetOwnNamespace: false
+  otherTargetNamespaces:
+
+operators:
+- channel: stable
+  installPlanApproval: Manual
+  name: costmanagement-metrics-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  csv: costmanagement-metrics-operator.2.0.0
+  namespace: costmanagement-metrics-operator
+  installPlanVerifierActiveDeadlineSeconds: 1200

--- a/charts/operators-installer/templates/Job_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: installplan-approver--{{ .csv }}
+  name: {{ printf "%s-%s" .csv "-approver" | trunc -63 | trimAll "-" }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: installplan-complete-verifier--{{ .csv }}
+  name: {{ printf "%s-%s" .csv "-verifier" | trunc -63 | trimAll "-" }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}


### PR DESCRIPTION
#### What is this PR About?
the verifyer and approver job names can get to long, need to put in smarts to truncate them.

#### How do we test this?
added a test, but actaully the test doesnt trigger the length problem because i can't find an operator thats name is to long now that i have shortnered the job name to just be "verifer" and "approver" rather then "install-plan-verifer" and "install-plan-approver" but you can run a local helm template with a made up operator name that is long and see it fail.

if anyone happens to know of an operator csv that is 54+ characters let me know.

cc: @redhat-cop/day-in-the-life
