### PR TITLE
operators-installer - fix issue where if multiple charts use this chart as a dependency to install operators into the same namespace then the Role, RB, and SAs would conflict

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.4
+version: 2.3.5
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/templates/Job_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yaml
@@ -98,8 +98,8 @@ spec:
           value: {{ .name }}
       dnsPolicy: ClusterFirst
       restartPolicy: Never
-      serviceAccount: installplan-approver
-      serviceAccountName: installplan-approver
+      serviceAccount: {{ include "operators-installer.approverName" . }}
+      serviceAccountName: {{ include "operators-installer.approverName" . }}
       terminationGracePeriodSeconds: 30
 {{- end }}
 {{- end }}

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
@@ -98,8 +98,8 @@ spec:
           value: {{ .name }}
       dnsPolicy: ClusterFirst
       restartPolicy: Never
-      serviceAccount: installplan-approver
-      serviceAccountName: installplan-approver
+      serviceAccount: {{ include "operators-installer.approverName" . }}
+      serviceAccountName: {{ include "operators-installer.approverName" . }}
       terminationGracePeriodSeconds: 30
 {{- end }}
 {{- end }}

--- a/charts/operators-installer/templates/RoleBinding_installplan-approvers.yaml
+++ b/charts/operators-installer/templates/RoleBinding_installplan-approvers.yaml
@@ -1,11 +1,16 @@
-{{- range $namespace := (include "operators-installer.uniqueNamespaces" $ | fromJsonArray) }}
+{{- /*
+Create one RoleBinding per operator that needs to be approved.
+NOTE: used to do this one per namespace, but that has issues if using this chart as dependency in multiple parent charts that are all
+installing into the same namespace. So while this creates more resources, it allows for more robust use.
+*/}}
+{{- range .Values.operators }}
+{{- if eq .installPlanApproval "Manual" }}
 ---
-# create one installplan-approvers RoleBinding per unqiue namespace operators are being installed in
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: installplan-approvers
-  namespace: {{ $namespace }}
+  name: {{ include "operators-installer.approverName" . }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
@@ -19,8 +24,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: installplan-approver
+  name: {{ include "operators-installer.approverName" . }}
 subjects:
   - kind: ServiceAccount
-    name: installplan-approver
+    name: {{ include "operators-installer.approverName" . }}
+{{- end }}
 {{- end }}

--- a/charts/operators-installer/templates/Role_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Role_installplan-approver.yaml
@@ -1,11 +1,16 @@
-{{- range $namespace := (include "operators-installer.uniqueNamespaces" $ | fromJsonArray) }}
+{{- /*
+Create one Role per operator that needs to be approved.
+NOTE: used to do this one per namespace, but that has issues if using this chart as dependency in multiple parent charts that are all
+installing into the same namespace. So while this creates more resources, it allows for more robust use.
+*/}}
+{{- range .Values.operators }}
+{{- if eq .installPlanApproval "Manual" }}
 ---
-# create one installplan-approver Role per unqiue namespace operators are being installed in
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: installplan-approver
-  namespace: {{ $namespace }}
+  name: {{ include "operators-installer.approverName" . }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
@@ -26,4 +31,5 @@ rules:
   - get
   - list
   - patch
+{{- end }}
 {{- end }}

--- a/charts/operators-installer/templates/ServiceAccount_installplan-approver.yaml
+++ b/charts/operators-installer/templates/ServiceAccount_installplan-approver.yaml
@@ -1,11 +1,16 @@
-{{- range $namespace := (include "operators-installer.uniqueNamespaces" $ | fromJsonArray) }}
+{{- /*
+Create one SA per operator that needs to be approved.
+NOTE: used to do this one per namespace, but that has issues if using this chart as dependency in multiple parent charts that are all
+installing into the same namespace. So while this creates more resources, it allows for more robust use.
+*/}}
+{{- range .Values.operators }}
+{{- if eq .installPlanApproval "Manual" }}
 ---
-# create one installplan-approver ServiceAccount per unqiue namespace operators are being installed in
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: installplan-approver
-  namespace: {{ $namespace }}
+  name: {{ include "operators-installer.approverName" . }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}
   annotations:
@@ -16,4 +21,5 @@ metadata:
     {{- else }}
     argocd.argoproj.io/sync-wave: "-30"
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/operators-installer/templates/_helpers.tpl
+++ b/charts/operators-installer/templates/_helpers.tpl
@@ -54,16 +54,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Unique namespaces from list of operators
+Name to use for approver SA, Role, and RoleBinding
 */}}
-{{- define "operators-installer.uniqueNamespaces" -}}
-{{-   $uniqueNamespaces := list }}
-{{-   range .Values.operators }}
-{{-     if .namespace }}
-{{-       $uniqueNamespaces = append $uniqueNamespaces .namespace | uniq }}
-{{-     else }}
-{{-       $uniqueNamespaces = append $uniqueNamespaces $.Release.Namespace | uniq }}
-{{-     end }}
-{{-   end }}
-{{    toJson $uniqueNamespaces }}
+{{- define "operators-installer.approverName" -}}
+{{- printf "%s-%s" .csv "-approver" | trunc -63 | trimAll "-" }}
 {{- end }}


### PR DESCRIPTION
#### What is this PR About?
operators-installer - fix issue where if multiple charts use this chart as a dependency to install operators into the same namespace then the Role, RB, and SAs would conflict

#### How do we test this?
the tests ensure no regression

cc: @redhat-cop/day-in-the-life
