### PR TITLE
operators-installer - deal with when channel names look like numbers, but they need to string

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.5
+version: 2.3.6
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/ci/test-install-multiple-operators-in-different-namespace-approve-via-helm-hook-values.yaml
+++ b/charts/operators-installer/ci/test-install-multiple-operators-in-different-namespace-approve-via-helm-hook-values.yaml
@@ -3,27 +3,30 @@ approveManualInstallPlanViaHook: true
 installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.12
 
 operatorGroups:
-- name: community-operators
-  createNamespace: true
-  targetOwnNamespace: true
-  otherTargetNamespaces:
+  community:
+    name: community-operators
+    createNamespace: true
+    targetOwnNamespace: true
+    otherTargetNamespaces:
 
 operators:
-- channel: stable
-  installPlanApproval: Manual
-  name: external-secrets-operator
-  source: operatorhubio-catalog
-  sourceNamespace: olm
-  csv: external-secrets-operator.v0.8.1
-  namespace: community-operators
-  installPlanVerifierActiveDeadlineSeconds: 1200
-- channel: alpha
-  installPlanApproval: Manual
-  name: argocd-operator
-  source: operatorhubio-catalog
-  sourceNamespace: olm
-  csv: argocd-operator.v0.6.0
-  namespace: community-operators
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  eso:
+    channel: stable
+    installPlanApproval: Manual
+    name: external-secrets-operator
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+    csv: external-secrets-operator.v0.8.1
+    namespace: community-operators
+    installPlanVerifierActiveDeadlineSeconds: 1200
+  argocd:
+    channel: alpha
+    installPlanApproval: Manual
+    name: argocd-operator
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+    csv: argocd-operator.v0.6.0
+    namespace: community-operators
+    installPlanVerifierActiveDeadlineSeconds: 1200
 commonLabels:
   test-label: xyz123

--- a/charts/operators-installer/ci/test-install-operator-with-channel-number.yaml
+++ b/charts/operators-installer/ci/test-install-operator-with-channel-number.yaml
@@ -1,0 +1,19 @@
+approveManualInstallPlanViaHook: false
+
+installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.12
+
+operatorGroups:
+  aqua:
+    name: aqua
+    createNamespace: true
+    targetOwnNamespace: false
+    otherTargetNamespaces: []
+
+operators:
+  aqua:
+    channel: "2022.4.0"
+    installPlanApproval: Manual
+    name: aqua-operator-certified
+    source: operatorhubio-catalog
+    sourceNamespace: openshift-marketplace
+    csv: aqua-operator.v2022.4.348

--- a/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
+++ b/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
@@ -3,17 +3,19 @@ approveManualInstallPlanViaHook: false
 installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.12
 
 operatorGroups:
-- name: costmanagement-metrics-operator
-  createNamespace: true
-  targetOwnNamespace: false
-  otherTargetNamespaces:
+  cmo:
+    name: costmanagement-metrics-operator
+    createNamespace: true
+    targetOwnNamespace: false
+    otherTargetNamespaces:
 
 operators:
-- channel: stable
-  installPlanApproval: Manual
-  name: costmanagement-metrics-operator
-  source: operatorhubio-catalog
-  sourceNamespace: olm
-  csv: costmanagement-metrics-operator.2.0.0
-  namespace: costmanagement-metrics-operator
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  cmo:
+    channel: stable
+    installPlanApproval: Manual
+    name: costmanagement-metrics-operator
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+    csv: costmanagement-metrics-operator.2.0.0
+    namespace: costmanagement-metrics-operator
+    installPlanVerifierActiveDeadlineSeconds: 1200

--- a/charts/operators-installer/templates/Subscription.yaml
+++ b/charts/operators-installer/templates/Subscription.yaml
@@ -11,10 +11,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-40"
 spec:
-  channel: {{ .channel }}
-  installPlanApproval: {{ .installPlanApproval }}
-  name: {{ .name }}
-  source: {{ .source }}
-  sourceNamespace: {{ .sourceNamespace }}
-  startingCSV: {{ .csv }}
+  channel: "{{ .channel }}"
+  installPlanApproval: "{{ .installPlanApproval }}"
+  name: "{{ .name }}"
+  source: "{{ .source }}"
+  sourceNamespace: "{{ .sourceNamespace }}"
+  startingCSV: "{{ .csv }}"
 {{- end }}


### PR DESCRIPTION
#### What is this PR About?
operators-installer - deal with when channel names look like numbers, but they need to string

#### How do we test this?
added a new test

cc: @redhat-cop/day-in-the-life
