### PR TITLE
🍞 argocd 2.8.3 🍞

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.7.13
+appVersion: v2.8.3
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.7.13
+version: 0.8.3
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/templates/argocd-cr.yaml
+++ b/charts/gitops-operator/templates/argocd-cr.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.namespaces }}
 {{- range $ns := .Values.namespaces }}
 ---
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: {{ $.Values.name }}
@@ -19,7 +19,7 @@ spec:
   {{- $.Values.argocd_cr | toYaml | trim | nindent 2 }}
   {{- end }}
 ---
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: AppProject
 metadata:
   name: default

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -32,7 +32,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.7.13
+  version: v2.8.3
   applicationSet: {}
   notifications:
     enabled: true


### PR DESCRIPTION
#### What is this PR About?
- update to argocd 2.8.3
- this matches latest gitops 2.8.2 operator default
- update to argoproj.io/v1beta1

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
