### PR TITLE
DRAFT: operators-installer - fix warnings about unset securitycontext configuration

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.7
+version: 2.3.8
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/ci/test-install-multiple-operators-in-different-namespace-approve-via-helm-hook-values.yaml
+++ b/charts/operators-installer/ci/test-install-multiple-operators-in-different-namespace-approve-via-helm-hook-values.yaml
@@ -18,7 +18,7 @@ operators:
     sourceNamespace: olm
     csv: external-secrets-operator.v0.8.1
     namespace: community-operators
-    installPlanVerifierActiveDeadlineSeconds: 1200
+    installPlanVerifierActiveDeadlineSeconds: 1400
   argocd:
     channel: alpha
     installPlanApproval: Manual
@@ -27,6 +27,6 @@ operators:
     sourceNamespace: olm
     csv: argocd-operator.v0.6.0
     namespace: community-operators
-    installPlanVerifierActiveDeadlineSeconds: 1200
+    installPlanVerifierActiveDeadlineSeconds: 1400
 commonLabels:
   test-label: xyz123

--- a/charts/operators-installer/ci/test-install-multiple-operators-in-same-namespaces-approve-via-helm-hook-values.yaml
+++ b/charts/operators-installer/ci/test-install-multiple-operators-in-same-namespaces-approve-via-helm-hook-values.yaml
@@ -20,7 +20,7 @@ operators:
   sourceNamespace: olm
   csv: external-secrets-operator.v0.8.1
   namespace: external-secrets-operator3
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  installPlanVerifierActiveDeadlineSeconds: 1400
 - channel: alpha
   installPlanApproval: Manual
   name: argocd-operator
@@ -28,6 +28,6 @@ operators:
   sourceNamespace: olm
   csv: argocd-operator.v0.6.0
   namespace: argocd-operator
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  installPlanVerifierActiveDeadlineSeconds: 1400
 commonLabels:
   test-label: xyz123

--- a/charts/operators-installer/ci/test-install-old-operator-approve-not-via-helm-hook-values.yaml
+++ b/charts/operators-installer/ci/test-install-old-operator-approve-not-via-helm-hook-values.yaml
@@ -16,6 +16,6 @@ operators:
   sourceNamespace: olm
   csv: external-secrets-operator.v0.8.1
   namespace: external-secrets-operator2
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  installPlanVerifierActiveDeadlineSeconds: 1400
 commonLabels:
   test-label: xyz123

--- a/charts/operators-installer/ci/test-install-old-operator-approve-via-helm-hook-values.yaml
+++ b/charts/operators-installer/ci/test-install-old-operator-approve-via-helm-hook-values.yaml
@@ -16,6 +16,6 @@ operators:
   sourceNamespace: olm
   csv: external-secrets-operator.v0.8.1
   namespace: external-secrets-operator1
-  installPlanVerifierActiveDeadlineSeconds: 1200
+  installPlanVerifierActiveDeadlineSeconds: 1400
 commonLabels:
   test-label: xyz123

--- a/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
+++ b/charts/operators-installer/ci/test-install-operator-with-long-name.yaml
@@ -18,4 +18,4 @@ operators:
     sourceNamespace: olm
     csv: costmanagement-metrics-operator.2.0.0
     namespace: costmanagement-metrics-operator
-    installPlanVerifierActiveDeadlineSeconds: 1200
+    installPlanVerifierActiveDeadlineSeconds: 1400

--- a/charts/operators-installer/templates/Job_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yaml
@@ -27,6 +27,14 @@ spec:
       containers:
       - name: installplan-approver
         image: {{ $.Values.installPlanApproverAndVerifyJobsImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         command:
           - /bin/bash
           - -c

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
@@ -27,6 +27,14 @@ spec:
       containers:
       - name: installplan-complete-verifier
         image: {{ $.Values.installPlanApproverAndVerifyJobsImage }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         command:
           - /bin/bash
           - -c


### PR DESCRIPTION
#### What is this PR About?
fix warning messages about security context information not set in jobs when applying against openshift

Warning 1
```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "installplan-approver" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "installplan-approver" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "installplan-approver" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "installplan-approver" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Warning 2
```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "installplan-complete-verifier" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "installplan-complete-verifier" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "installplan-complete-verifier" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "installplan-complete-verifier" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

#### How do we test this?
the built in tests should ensure no regression.

i manually tested applying against a 4.12 openshift cluster and checking that the warning messages went away.



cc: @redhat-cop/day-in-the-life
