### PR TITLE
operators-installer - approveManualInstallPlanViaHook change default …

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.7
+version: 2.4.0
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -7,7 +7,7 @@
 # which means you will never get to that phase because your CustomResources wont be able to apply because the Operator isn't installed.
 # This is is ultimately a trade off between cleaning up these resources or being able to install and configure the operator in the same
 # helm chart that has a dependency on this helm chart.
-approveManualInstallPlanViaHook: true
+approveManualInstallPlanViaHook: false
 
 # Image to use for the InstallPlan Approver and Verify Jobs
 installPlanApproverAndVerifyJobsImage: registry.redhat.io/openshift4/ose-cli:v4.10


### PR DESCRIPTION
#### What is this PR About?
approveManualInstallPlanViaHook change default to false because while cleaning up via hooks is nice, in practice the downside of not being able to apply other config is to great

#### How do we test this?
the automated tests should check for any regressions.

cc: @redhat-cop/day-in-the-life
