### PR TITLE
Add spec.config to OLM Subscription objet

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.4.1
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/ci/test-install-operator-subscription-with-config.yaml
+++ b/charts/operators-installer/ci/test-install-operator-subscription-with-config.yaml
@@ -1,0 +1,20 @@
+approveManualInstallPlanViaHook: true
+
+installPlanApproverAndVerifyJobsImage: registry.redhat.io/openshift4/ose-cli:v4.12
+
+operators:
+- channel: gitops-1.10
+  installPlanApproval: Manual
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  csv: openshift-gitops-operator.v1.10.1
+  namespace: openshift-gitops-operator
+  config:
+    env:
+    - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+      value: "true"
+
+operatorGroups:
+- name: openshift-gitops-operator
+  createNamespace: openshift-gitops-operator

--- a/charts/operators-installer/templates/Job_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ printf "%s-%s" .csv "-approver" | trunc -63 | trimAll "-" }}
+  name: {{ printf "%s-%s" .csv "approver" | trunc -63 | trimAll "-" }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ printf "%s-%s" .csv "-verifier" | trunc -63 | trimAll "-" }}
+  name: {{ printf "%s-%s" .csv "verifier" | trunc -63 | trimAll "-" }}
   namespace: {{ .namespace | default $.Release.Namespace }}
   labels:
     {{- include "operators-installer.labels" $ | nindent 4 }}

--- a/charts/operators-installer/templates/Subscription.yaml
+++ b/charts/operators-installer/templates/Subscription.yaml
@@ -12,6 +12,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "-40"
 spec:
   channel: "{{ .channel }}"
+  {{- if .config }}
+  config:
+    {{ .config | toYaml | indent 4 | trim }}
+  {{- end }}
   installPlanApproval: "{{ .installPlanApproval }}"
   name: "{{ .name }}"
   source: "{{ .source }}"

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -20,6 +20,16 @@ operators:
 #   source: community-operators
 #   sourceNamespace: openshift-marketplace
 #   csv: external-secrets-operator.v0.8.2
+# - channel: gitops-1.10
+#   installPlanApproval: Manual
+#   name: openshift-gitops-operator
+#   source: redhat-operators
+#   sourceNamespace: openshift-marketplace
+#   csv: openshift-gitops-operator.v1.10.1
+#   config:
+#     env:
+#     - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+#       value: "true"
 
 # configuration for control of OperatorGroups
 operatorGroups:

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -26,6 +26,7 @@ operators:
 #   source: redhat-operators
 #   sourceNamespace: openshift-marketplace
 #   csv: openshift-gitops-operator.v1.10.1
+#   namespace: openshift-gitops-operator
 #   config:
 #     env:
 #     - name: DISABLE_DEFAULT_ARGOCD_INSTANCE


### PR DESCRIPTION
#### What is this PR About?
Adds spec.config option to the OLM Subscription object.
Required by some operators such as [OpenShift Gitops Operator](https://developers.redhat.com/articles/2023/03/06/5-global-environment-variables-provided-openshift-gitops)

#### How do we test this?
.
cc: @redhat-cop/day-in-the-life
