### PR TITLE
auto bump chart version when its a renovate pr

### DIFF
--- a/.github/renovate-bump.sh
+++ b/.github/renovate-bump.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CHARTS_CHANGED=()
+changed=$(ct list-changed)
+for chart in ${changed}; do
+  echo "Chart has changes: ${chart}"
+
+  hasVersionBumped=$(git --no-pager diff "${chart}/Chart.yaml" | grep "+version" | wc -l)
+  if [[ "${hasVersionBumped}" -eq 0 ]]; then
+    echo "-> Version has not been bumped. Bumping to:"
+    pybump bump --file "${chart}/Chart.yaml" --level patch
+
+    CHARTS_CHANGED+=("${chart}/Chart.yaml")
+  fi
+
+  echo
+done
+
+echo "CHARTS=$(echo ${CHARTS_CHANGED[*]})" >> $GITHUB_OUTPUT

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Conftest
-        uses: redhat-cop/github-actions/confbatstest@master
+        uses: redhat-cop/github-actions/confbatstest@11f2ce27643eb7c76ac3623cb99d9b08be30d762 # v4
         with:
           tests: _test/conftest.sh

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -14,6 +14,15 @@ concurrency:
 jobs:
   install-test:
     runs-on: ubuntu-latest
+    env:
+      # renovate: datasource=github-releases depName=helm/helm
+      HELM_VERSION: v3.13.0
+      # renovate: datasource=github-releases depName=StyraInc/regal
+      PYTHON_VERSION: 3.11
+      # renovate: datasource=github-releases depName=kubernetes-sigs/kind/
+      KIND_VERSION: v0.20.0
+      # renovate: datasource=github-releases depName=operator-framework/operator-lifecycle-manager
+      OLM_VERSION: v0.25.0
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -23,12 +32,12 @@ jobs:
     - name: Setup Helm 🧰
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       with:
-        version: v3.13.0
+        version: ${{ env.HELM_VERSION }}
 
     - name: Setup Python 🐍
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
       with:
-        python-version: 3.11
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup chart-testing 🧰
       uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
@@ -45,15 +54,15 @@ jobs:
     - name: Setup kind cluster 🧰
       uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
       with:
-        version: v0.20.0
+        version: ${{ env.KIND_VERSION }}
       if: steps.changed-charts.outputs.changed == 'true'
 
     # for helm charts we are testing that require installing operators 
     - name: Setup kind cluster - Install OLM 🧰
       run: |
-        curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.25.0/install.sh -o install.sh
+        curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh -o install.sh
         chmod +x install.sh
-        ./install.sh v0.25.0
+        ./install.sh ${OLM_VERSION}
       if: steps.changed-charts.outputs.changed == 'true'
 
     # for helm charts we are testing that require ingress

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -17,9 +17,9 @@ jobs:
     env:
       # renovate: datasource=github-releases depName=helm/helm
       HELM_VERSION: v3.13.0
-      # renovate: datasource=github-releases depName=StyraInc/regal
+      # renovate: datasource=github-tags depName=python/cpython
       PYTHON_VERSION: 3.11
-      # renovate: datasource=github-releases depName=kubernetes-sigs/kind/
+      # renovate: datasource=github-releases depName=kubernetes-sigs/kind
       KIND_VERSION: v0.20.0
       # renovate: datasource=github-releases depName=operator-framework/operator-lifecycle-manager
       OLM_VERSION: v0.25.0

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -23,12 +23,12 @@ jobs:
     - name: Setup Helm 🧰
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       with:
-        version: v3.5.1
+        version: v3.13.0
 
     - name: Setup Python 🐍
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
       with:
-        python-version: 3.7
+        python-version: 3.11
 
     - name: Setup chart-testing 🧰
       uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   lint-test:
+    env:
+      branch_name: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout 🛎️
@@ -22,15 +24,43 @@ jobs:
     - name: Setup Helm 🧰
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       with:
-        version: v3.5.1
+        version: v3.13.0
 
     - name: Setup Python 🐍
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
       with:
-        python-version: 3.7
+        python-version: 3.11
 
     - name: Setup chart-testing 🧰
       uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
 
+    - name: Setup pybump
+      if: ${{ contains(env.branch_name, 'renovate') }}
+      run: |
+        pip3 install pybump
+
+    - name: Bump chart version
+      if: ${{ contains(env.branch_name, 'renovate') }}
+      id: bumped_charts
+      run: |
+        .github/renovate-bump.sh
+
     - name: Run Chart lint tests 🧪
       run: ct lint
+
+    # Use the REST API to commit changes, so we get automatic commit signing
+    - name: Push changes
+      if: ${{ contains(env.branch_name, 'renovate') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        changed_charts: ${{ steps.bumped_charts.outputs.CHARTS }}
+      run: |
+        for chart in ${changed_charts}; do
+          export SHA=$(git rev-parse origin/${branch_name}:${chart} )
+
+          gh api --method PUT /repos/:owner/:repo/contents/${chart} \
+            --field message="chore: bumped ${chart} version" \
+            --field content=@<( base64 -i ${chart} ) \
+            --field branch="${branch_name}" \
+            --field sha="$SHA"
+        done

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,7 +16,7 @@ jobs:
       branch_name: ${{ github.head_ref || github.ref_name }}
       # renovate: datasource=github-releases depName=helm/helm
       HELM_VERSION: v3.13.0
-      # renovate: datasource=github-releases depName=StyraInc/regal
+      # renovate: datasource=github-tags depName=python/cpython
       PYTHON_VERSION: 3.11
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,6 +14,10 @@ jobs:
   lint-test:
     env:
       branch_name: ${{ github.head_ref || github.ref_name }}
+      # renovate: datasource=github-releases depName=helm/helm
+      HELM_VERSION: v3.13.0
+      # renovate: datasource=github-releases depName=StyraInc/regal
+      PYTHON_VERSION: 3.11
     runs-on: ubuntu-latest
     steps:
     - name: Checkout 🛎️
@@ -24,12 +28,12 @@ jobs:
     - name: Setup Helm 🧰
       uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       with:
-        version: v3.13.0
+        version: ${{ env.HELM_VERSION }}
 
     - name: Setup Python 🐍
       uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
       with:
-        python-version: 3.11
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup chart-testing 🧰
       uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '.github/**'
       - 'README.md'
@@ -12,6 +12,9 @@ jobs:
   release:
     concurrency: staging_environment
     runs-on: ubuntu-latest
+    env:
+      # renovate: datasource=github-releases depName=helm/helm
+      HELM_VERSION: v3.13.0
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -26,7 +29,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.13.0
+          version: ${{ env.HELM_VERSION }}
 
       - name: Add dependency chart repos
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: latest 
+          version: v3.13.0
 
       - name: Add dependency chart repos
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:best-practices",
     "schedule:earlyMondays"
-  ]
+  ],
+  "bumpVersion": "patch"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
+    "regexManagers:githubActionsVersions",
     "schedule:earlyMondays"
   ],
   "bumpVersion": "patch"


### PR DESCRIPTION
renovate PRs that change a values.yaml dont bump the chart version, so the ci fails on linting. this PR targets those PRs, by bumping the version and pushing a change to that PR.

renovate doesn't support bumping chart versions when values.yaml are changed, and the only other solution provided is for the self-hosted which we don't use.

the only weird thing about this change, is that after the commit for bumping the versions, the CI on the PR doesn't show anymore, but it is still running for the original commit from renovate. but it is slightly confusing.

**pink** is the CI running on the renovate commit.
**green** is CI being disabled by renovate, because someone else (the github action) pushed a change

<img width="960" alt="Screenshot 2023-11-22 at 10 48 33" src="https://github.com/redhat-cop/helm-charts/assets/8656974/375f642c-e7e3-42be-a5c2-7872c01183b9">
