### PR TITLE
added scorecard and readme badges for ci

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -7,6 +7,9 @@ on:
     - .github/**
     - charts/**
 
+# Declare default permissions as read only.
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   lint-test:
     env:
@@ -18,7 +21,11 @@ jobs:
       HELM_VERSION: v3.13.2
       # renovate: datasource=github-tags depName=python/cpython
       PYTHON_VERSION: v3.12.1
+      # renovate: datasource=pypi depName=pybump
+      PYBUMP_VERSION: 1.11.4
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -41,7 +48,7 @@ jobs:
     - name: Setup pybump
       if: ${{ contains(env.branch_name, 'renovate') }}
       run: |
-        pip3 install pybump
+        pip3 install pybump==${PYBUMP_VERSION}
 
     - name: Bump chart version
       if: ${{ contains(env.branch_name, 'renovate') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
       - '.github/**'
       - 'README.md'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   release:
     concurrency: staging_environment
@@ -15,6 +18,8 @@ jobs:
     env:
       # renovate: datasource=github-releases depName=helm/helm
       HELM_VERSION: v3.13.2
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,72 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '36 19 * * 3'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@c0d1daa7f7e14667747d73a7dbbe8c074bc8bfe2 # v2.22.9
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ⚓️ Red Hat Communities of Practice Helm Charts
 
-![Release Charts](https://github.com/redhat-cop/helm-charts/workflows/Release%20Charts/badge.svg)
+[![Install Test](https://github.com/redhat-cop/helm-charts/actions/workflows/install-test.yaml/badge.svg)](https://github.com/redhat-cop/helm-charts/actions/workflows/install-test.yaml)
+[![Lint Test](https://github.com/redhat-cop/helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/redhat-cop/helm-charts/actions/workflows/lint-test.yaml)
+[![Release Charts](https://github.com/redhat-cop/helm-charts/actions/workflows/release.yaml/badge.svg)](https://github.com/redhat-cop/helm-charts/actions/workflows/release.yaml)
+[![Scorecard supply-chain security](https://github.com/redhat-cop/helm-charts/actions/workflows/scorecard.yml/badge.svg)](https://github.com/redhat-cop/helm-charts/actions/workflows/scorecard.yml)
 
 A collection of Helm Charts to that are not available in any upstream location or customised to the point it does not make sense to support up stream chart development.
 


### PR DESCRIPTION
[scorecard ](https://github.com/ossf/scorecard) gives suggestions on how secure the repo is, that's why the actions have explicit permissions added

cc: @redhat-cop/day-in-the-life
