### PR TITLE
Update values.yaml to use valid free-ipa image

### DIFF
--- a/charts/ipa/Chart.yaml
+++ b/charts/ipa/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ipa
 description: A Helm chart to install FreeIPA
-version: 1.3.6
+version: 1.3.7
 appVersion: 1.16.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.freeipa.org/images/freeipa/freeipa-logo-small.png

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -5,7 +5,7 @@ admin_password: Passw0rd123
 realm: "-r redhatlabs.dev"
 
 # sensible defaults
-image: quay.io/freeipa/freeipa-server:fedora-39@sha256:af20b8cf31e66db582301f40ae01d17ec05e2e54de633c8dff427410dce95894
+image: quay.io/freeipa/freeipa-server:fedora-39
 install_opts: "-U --setup-dns --no-forwarders --no-ntp"
 container_args: "ipa-server-install"
 volume: 5Gi

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -5,7 +5,7 @@ admin_password: Passw0rd123
 realm: "-r redhatlabs.dev"
 
 # sensible defaults
-image: quay.io/freeipa/freeipa-server:fedora-39
+image: quay.io/freeipa/freeipa-server:fedora-39-4.11.1
 install_opts: "-U --setup-dns --no-forwarders --no-ntp"
 container_args: "ipa-server-install"
 volume: 5Gi


### PR DESCRIPTION
#### What is this PR About?
IPA is not getting ready due to invalid image tag provided here, so I think we may need to update this image tag.
No manifest found for this tag: https://quay.io/repository/freeipa/freeipa-server/manifest/sha256:af20b8cf31e66db582301f40ae01d17ec05e2e54de633c8dff427410dce95894. So we should update this

#### How do we test this?
Provide commands/steps to test this PR.

cc: @redhat-cop/day-in-the-life
