### PR TITLE
disabled freeipa digest pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,15 @@
         "pinDigest"
       ],
       "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "quay.io/freeipa/freeipa-server"
+      ],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
theres been 2 PRs related to removing the digest from freeipa. the digest is added by renovate but because the upstream is rebuilding the same tag, the digest moves which causes a unknown manifest. this PR disables digest pinning for that image.
