### PR TITLE
🏖️ argocd 2.10.5 🏖️

### DIFF
--- a/charts/gitops-operator/Chart.yaml
+++ b/charts/gitops-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v2.9.5
+appVersion: v2.10.5
 description: A Helm chart for customising the deployment of the Red Hat GitOps Operator 🔫
 name: gitops-operator
-version: 0.9.5
+version: 0.10.5
 home: https://github.com/redhat-cop/helm-charts
 icon: https://raw.githubusercontent.com/eformat/openshift-gitops/main/rh-gitops.png
 maintainers:

--- a/charts/gitops-operator/values.yaml
+++ b/charts/gitops-operator/values.yaml
@@ -32,7 +32,7 @@ secrets: []
 
 # https://argocd-operator.readthedocs.io/en/latest/reference/argocd/
 argocd_cr:
-  version: v2.9.5
+  # version: v2.10.5 # set this if you want the upstream containers instead
   applicationSet: {}
   notifications:
     enabled: true


### PR DESCRIPTION
#### What is this PR About?
update to use the version that the operator default sets - currently at argocd 2.10.5
if you set the version explicitly in values.yaml - this uses the upstream image versions as before.

#### How do we test this?
helm install

cc: @redhat-cop/day-in-the-life
