### PR TITLE
🏖️ add MachineConfig enabled flag 🏖️

### DIFF
--- a/charts/ipa/Chart.yaml
+++ b/charts/ipa/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ipa
 description: A Helm chart to install FreeIPA
-version: 1.3.7
+version: 1.3.8
 appVersion: 1.16.0
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.freeipa.org/images/freeipa/freeipa-logo-small.png

--- a/charts/ipa/templates/machineconfig.yaml
+++ b/charts/ipa/templates/machineconfig.yaml
@@ -1,4 +1,5 @@
 # https://access.redhat.com/solutions/4910611
+{{- if .Values.machineconfig.enabled }}
 ---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -26,3 +27,4 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: sebool.service
+{{- end }}

--- a/charts/ipa/values.yaml
+++ b/charts/ipa/values.yaml
@@ -24,6 +24,7 @@ ocp_auth:
   domain: "dc=redhatlabs,dc=dev"
 
 machineconfig:
+  enabled: true
   ignition_version: 3.2.0
 
 # assumes node-role.kubernetes.io/infra: "" on one or more nodes


### PR DESCRIPTION
#### What is this PR About?
When running Hosted Control Plane cluster with ipa chart in a hcp spoke - we cannot control the MachineConfig directly
so adding an enabled flag to allow this to be optional.

#### How do we test this?
helm install --set machineconfig.enabled=false

cc: @redhat-cop/day-in-the-life
