### PR TITLE
Bump vulnerable Nexus version to 3.72.0-ubi-1

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -6,7 +6,7 @@ name: sonatype-nexus
 sources:
 - https://github.com/sonatype/nexus-public
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
-version: 1.1.11
+version: 1.1.12
 maintainers:
   - name: eformat
   - name: ckavili

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -37,7 +37,7 @@ nexus:
   - name: NEXUS_SECURITY_RANDOMPASSWORD
     value: "false"
   hostAliases: []
-  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.43.0-ubi-1
+  imageName: registry.connect.redhat.com/sonatype/nexus-repository-manager:3.72.0-ubi-1
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   livenessProbe:


### PR DESCRIPTION
During the hands-on session of TL500 a vulnerability warning message pops up when Sonatype Nexus Repo manager is starting up

#### What is this PR About?
Bump the default Nexus version.

#### How do we test this?
[Link to the test exercise](https://rht-labs.com/tech-exercise/#/1-the-manual-menace/4-extend-uj)

cc: @redhat-cop/day-in-the-life
