### PR TITLE
Fix: move Jenkins gitlab token outside a helm condition

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v2.222.1"
 description: A Helm chart for deploying Jenkins on OpenShift with some additional build agents and plugins
 name: jenkins
-version: 1.0.12
+version: 1.0.13
 home: https://github.com/redhat-cop/helm-charts
 icon: https://www.jenkins.io/images/logos/jenkins/256.png
 maintainers:

--- a/charts/jenkins/templates/deployment.yaml
+++ b/charts/jenkins/templates/deployment.yaml
@@ -47,14 +47,14 @@ spec:
           value: 'false'
         - name: JENKINS_OPTS
           value: '--sessionTimeout=180'
-        {{- if .Values.configAsCode }}
-        - name: CASC_JENKINS_CONFIG
-          value: /var/lib/jenkins/config-as-code
         - name: GITLAB_TOKEN
           valueFrom:
             secretKeyRef:
               name: git-auth
               key: password
+        {{- if .Values.configAsCode }}
+        - name: CASC_JENKINS_CONFIG
+          value: /var/lib/jenkins/config-as-code
         {{- end }}
         {{- range $key := .Values.deployment.env_vars }}
         {{- if .value }}


### PR DESCRIPTION
#### What is this PR About?
The Deployment works just fine, was just not picking up the token.

#### How do we test this?
Update your ubiquitous-journey/values-tooling.yaml:

      # Jenkins
      - name: jenkins
        source_ref: "jenkins-1.0.13"


