### PR TITLE
issue #622 - operators-installer - need to handle when API call to approve InstallPlan fails

### DIFF
--- a/.github/workflows/install-integration-tests-operators-installer.yaml
+++ b/.github/workflows/install-integration-tests-operators-installer.yaml
@@ -38,16 +38,29 @@ jobs:
     - name: Run integration tests 🧪
       timeout-minutes: 30
       run: |
+        echo
         echo "##########################################################################################################"
         echo "# Install argo at old version                                                                            #"
         echo "##########################################################################################################"
+        helm_exit_status=0
         helm upgrade --install install-and-multi-stage-upgrade charts/operators-installer \
           --namespace ${TEST_NAMESPACE} \
           --create-namespace \
           --wait \
           --values charts/operators-installer/_integration-tests/test-install-operator-0-automatic-intermediate-manual-upgrades-values.yaml \
-          --debug --timeout 10m0s
+          --debug --timeout 10m0s \
+          || helm_exit_status=$?
 
+        # debug logging
+        ./_test/helm-install-debug-logging.sh ${TEST_NAMESPACE}
+
+        if [ ${helm_exit_status} -ne 0 ]; then
+          echo
+          echo "ERROR: failed to install helm chart. see above logs"
+          exit ${helm_exit_status}
+        fi
+
+        echo
         echo "##########################################################################################################"
         echo "# Upgrade argo to newer version requiring many intermediate updates along the way                        #"
         echo "##########################################################################################################"
@@ -55,7 +68,17 @@ jobs:
           --namespace ${TEST_NAMESPACE} \
           --wait \
           --values charts/operators-installer/_integration-tests/test-install-operator-1-automatic-intermediate-manual-upgrades-values.yaml \
-          --debug --timeout 30m0s
+          --debug --timeout 30m0s \
+          || helm_exit_status=$?
+
+        # debug logging
+        ./_test/helm-install-debug-logging.sh ${TEST_NAMESPACE}
+
+        if [ ${helm_exit_status} -ne 0 ]; then
+          echo
+          echo "ERROR: failed to install helm chart. see above logs"
+          exit ${helm_exit_status}
+        fi
 
   test-approver-job-image-from-authenticated-registry:
     runs-on: ubuntu-latest
@@ -99,6 +122,7 @@ jobs:
     - name: Run integration tests 🧪
       timeout-minutes: 10
       run: |
+        echo
         echo "##########################################################################################################"
         echo "# Install operator using approver job image from private authenticated registry                          #"
         echo "##########################################################################################################"
@@ -106,4 +130,14 @@ jobs:
           --namespace ${TEST_NAMESPACE} \
           --wait \
           --values charts/operators-installer/_integration-tests/test-install-operator-with-approver-image-from-private-registry.yaml \
-          --debug --timeout 9m0s
+          --debug --timeout 9m0s \
+          || helm_exit_status=$?
+
+        # debug logging
+        ./_test/helm-install-debug-logging.sh ${TEST_NAMESPACE}
+
+        if [ ${helm_exit_status} -ne 0 ]; then
+          echo
+          echo "ERROR: failed to install helm chart. see above logs"
+          exit ${helm_exit_status}
+        fi

--- a/.github/workflows/install-integration-tests-operators-installer.yaml
+++ b/.github/workflows/install-integration-tests-operators-installer.yaml
@@ -6,6 +6,7 @@
 name: Install Integration Tests - operators-installer
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - .github/**

--- a/.github/workflows/install-unit-test.yaml
+++ b/.github/workflows/install-unit-test.yaml
@@ -2,6 +2,7 @@
 name: Install Unit Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
     - .github/**

--- a/_test/helm-install-debug-logging.sh
+++ b/_test/helm-install-debug-logging.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TEST_NAMESPACE=$1
+
+echo
+echo "### Get Pods ###"
+kubectl get pods --namespace ${TEST_NAMESPACE}
+
+echo
+echo "### Describe Pods ###"
+kubectl describe pods --namespace ${TEST_NAMESPACE}
+
+echo
+echo "### Dump Pods Logs for debugging ###"
+kubectl get pods --namespace ${TEST_NAMESPACE} --output name  2>&1 | tee pods.csv
+while read pod || [ -n "${pod}" ]; do
+    kubectl logs ${pod} --namespace ${TEST_NAMESPACE}
+done < <(sort -u pods.csv)
+
+echo
+echo "### Get Jobs ###"
+kubectl get jobs --namespace ${TEST_NAMESPACE}
+
+echo
+echo "### Describe Jobs ###"
+kubectl describe jobs --namespace ${TEST_NAMESPACE}
+
+echo
+echo "### Dump Jobs Logs for debugging ###"
+kubectl get jobs --namespace ${TEST_NAMESPACE} --output name  2>&1 | tee jobs.csv
+while read job || [ -n "${job}" ]; do
+    kubectl logs job/${pod} --namespace ${TEST_NAMESPACE}
+done < <(sort -u jobs.csv)

--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.1
+version: 3.2.0
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/_scripts/installplan-approver.py
+++ b/charts/operators-installer/_scripts/installplan-approver.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-import sys
 import installplan_utils
 
 NAMESPACE_NAME = os.getenv("NAMESPACE") or installplan_utils.error_and_exit(
@@ -34,7 +33,7 @@ if subscription_uid:
     # find the InstallPlan that has expected owner subscription id and expected target CSV name
     # NOTE: if more then one InstallPlan matches, choose the first one
     print(
-        f"Find InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription (${subscription_uid}) owner"
+        f"Find InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription ({subscription_uid}) owner"
     )
     target_installplan = installplan_utils.get_installplan(
         NAMESPACE_NAME, CSV, subscription_uid
@@ -44,19 +43,24 @@ if subscription_uid:
     # else fail
     if target_installplan:
         print(f"\t- Found InstallPlan: {target_installplan.model.metadata.name}")
-        installplan_utils.approve_installplan(target_installplan)
-        sys.exit(0)
+        installplan_approved = installplan_utils.approve_installplan(target_installplan)
+        if installplan_approved:
+            installplan_utils.success_and_exit(
+                "InstallPlan ({target_installplan}) approved"
+            )
+        else:
+            installplan_utils.error_and_exit(
+                "ERROR: Failed to approve InstallPlan ({target_installplan})"
+                + "\nThis is typically an unrecoverable error due to an API call issue."
+                + "\nUnknown resolution at this time, more examples needed, please submit issue with any details"
+            )
     else:
-        print()
-        print(
-            f"ERROR: Could not find next InstallPlan to reach CSV ${CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
+        installplan_utils.error_and_exit(
+            f"ERROR: Could not find next InstallPlan to reach CSV {CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
             + "\nThis can happen if InstallPlan isn't created yet or no valid upgrade path between current CSV and target CSV."
             + "\nTry again."
         )
-        sys.exit(1)
 else:
-    print()
-    print(
+    installplan_utils.error_and_exit(
         f"ERROR: Failed to get Subscription ({SUBSCRIPTION_NAME}) UID. This really shouldn't happen."
     )
-    sys.exit(1)

--- a/charts/operators-installer/_scripts/installplan-incremental-approver.py
+++ b/charts/operators-installer/_scripts/installplan-incremental-approver.py
@@ -48,14 +48,14 @@ if subscription_uid:
         f"Find and approve every InstallPlan between currently installed CSV and target CSV ({CSV})"
     )
     target_installplan = None
-    approved_install_plans = []
+    installed_installplans = []
     attempt = 0
     while (target_installplan is None) or (
         CSV not in target_installplan.model.spec.clusterServiceVersionNames
     ):
         # find the next InstallPlan that has expected owner subscription id and expected target CSV name
         print(
-            f"\nFind next InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription (${subscription_uid}) owner"
+            f"\nFind next InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription ({subscription_uid}) owner"
         )
         target_installplan = installplan_utils.get_next_installplan(
             NAMESPACE_NAME, CSV, subscription_uid
@@ -64,25 +64,53 @@ if subscription_uid:
         # if found next InstallPlan, approve it
         # else fail
         if target_installplan:
+            target_installplan_name = target_installplan.model.metadata.name
             # if target install plan is not one we have already approved, then approve it
             # else wait and loop for next InstallPlan that installs a CSV less then or equal to our target CSV
             if target_installplan.model.metadata.name not in map(
                 lambda approved_install_plan: approved_install_plan.model.metadata.name,
-                approved_install_plans,
+                installed_installplans,
             ):
                 attempt = 0
                 print(
                     f"\t- Found next InstallPlan: {target_installplan.model.metadata.name}"
                 )
-                approved_install_plans.append(target_installplan)
-                installplan_utils.approve_installplan(target_installplan)
-                installplan_installed = (
-                    installplan_utils.verify_installplan_and_csv_installed(
-                        target_installplan,
-                        INCREMENTAL_INSTALL_BACKOFF_LIMIT,
-                        INCREMENTAL_INSTALL_DELAY_INCREMENT,
-                    )
+
+                installplan_approved = installplan_utils.approve_installplan(
+                    target_installplan
                 )
+                # if InstallPlan approved
+                # else unrecoverable error
+                if installplan_approved:
+                    installplan_installed, csvs_installed = (
+                        installplan_utils.verify_installplan_and_csv_installed(
+                            target_installplan,
+                            INCREMENTAL_INSTALL_BACKOFF_LIMIT,
+                            INCREMENTAL_INSTALL_DELAY_INCREMENT,
+                        )
+                    )
+
+                    # if InstallPlan and all target CSVs installed
+                    # else unrecoverable error
+                    if installplan_installed and csvs_installed:
+                        installed_installplans.append(target_installplan)
+                    else:
+                        error_message = "Unrecoverable unexpected issue with unknown resolution, see logs.\n"
+                        if not installplan_installed:
+                            error_message += f"InstallPlan ({target_installplan_name}) failed to install: {target_installplan}\n"
+                        if not csvs_installed:
+                            csvs = []
+                            for csv_name in (
+                                target_installplan.model.spec.clusterServiceVersionNames
+                            ):
+                                csvs += installplan_utils.get_csv(csv_name)
+                            error_message += f"InstallPlan ({target_installplan_name}) failed to install some/all target ClusterServiceVersions: {csvs}"
+
+                        installplan_utils.error_and_exit(error_message)
+                else:
+                    installplan_utils.error_and_exit(
+                        f"Unrecoverable unexpected issue with unknown resolution, see logs. Failed to approve InstallPlan ({target_installplan_name}): {target_installplan}"
+                    )
             else:
                 attempt += 1
                 # let everyone know what InstallPlans are currently available
@@ -109,22 +137,17 @@ if subscription_uid:
                     )
         else:
             installplan_utils.error_and_exit(
-                f"Could not find next InstallPlan to reach CSV ${CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
+                f"Could not find next InstallPlan to reach CSV {CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
                 + "\nThis can happen if InstallPlan isn't created yet or no valid upgrade path between current CSV and target CSV."
                 + "\nTry again.",
                 1,
             )
 
     # report success
-    print()
-    print(
-        f"Successfully installed target CSV ({CSV}) installed, approved intermediate InstallPlans include:"
-    )
-    for approved_install_plan in approved_install_plans:
-        print(
-            f"\t- {approved_install_plan.model.metadata.name}: {approved_install_plan.model.spec.clusterServiceVersionNames}"
-        )
-    sys.exit(0)
+    success_message = f"Successfully installed target CSV ({CSV}) installed, approved intermediate InstallPlans include:"
+    for approved_install_plan in installed_installplans:
+        success_message += f"\t- {approved_install_plan.model.metadata.name}: {approved_install_plan.model.spec.clusterServiceVersionNames}"
+    installplan_utils.success_and_exit(success_message)
 else:
     installplan_utils.error_and_exit(
         f"Failed to get Subscription ({SUBSCRIPTION_NAME}) UID. This really shouldn't happen."

--- a/charts/operators-installer/_scripts/installplan-incremental-approver.py
+++ b/charts/operators-installer/_scripts/installplan-incremental-approver.py
@@ -109,7 +109,7 @@ if subscription_uid:
                         installplan_utils.error_and_exit(error_message)
                 else:
                     installplan_utils.error_and_exit(
-                        f"Unrecoverable unexpected issue with unknown resolution, see logs. Failed to approve InstallPlan ({target_installplan_name}): {target_installplan}"
+                        f"Unrecoverable unexpected issue with unknown resolution, see logs. Failed to approve InstallPlan ({target_installplan_name}): {target_installplan.as_dict()}"
                     )
             else:
                 attempt += 1

--- a/charts/operators-installer/_scripts/installplan-verifier.py
+++ b/charts/operators-installer/_scripts/installplan-verifier.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 import os
-import sys
 import installplan_utils
 
 NAMESPACE_NAME = os.getenv("NAMESPACE") or installplan_utils.error_and_exit(
@@ -35,7 +34,7 @@ if subscription_uid:
     # find the InstallPlan that has expected owner subscription id and expected target CSV name
     # NOTE: if more then one InstallPlan matches, choose the first one
     print(
-        f"\tFind InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription (${subscription_uid}) owner"
+        f"\tFind InstallPlan in Namespace ({NAMESPACE_NAME}) for CSV ({CSV}) with Subscription ({subscription_uid}) owner"
     )
     target_installplan = installplan_utils.get_installplan(
         NAMESPACE_NAME, CSV, subscription_uid
@@ -52,28 +51,20 @@ if subscription_uid:
             1,
         )
         if installplan_installed:
-            print()
-            print(
-                f"InstallPlan ({target_installplan.model.metadata.name}) installation verified"
+            installplan_utils.success_and_exit(
+                f"InstallPlan ({target_installplan.model.metadata.name}) installed"
             )
-            sys.exit(0)
         else:
-            print()
-            print(
+            installplan_utils.error_and_exit(
                 f"InstallPlan ({target_installplan.model.metadata.name}) not yet installed. Suggest retry verification."
             )
-            sys.exit(1)
     else:
-        print()
-        print(
-            f"ERROR: Could not find next InstallPlan to reach CSV ${CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
+        installplan_utils.error_and_exit(
+            f"ERROR: Could not find next InstallPlan to reach CSV {CSV}) with Subscription ({SUBSCRIPTION_NAME}) ({subscription_uid}) owner."
             + "\nThis can happen if InstallPlan isn't created yet or no valid upgrade path between current CSV and target CSV."
             + "\nTry again."
         )
-        sys.exit(1)
 else:
-    print()
-    print(
+    installplan_utils.error_and_exit(
         f"ERROR: Failed to get Subscription ({SUBSCRIPTION_NAME}) UID. This really shouldn't happen."
     )
-    sys.exit(1)


### PR DESCRIPTION
#### What is this PR About?
resolves #622 


#### investigation
first commit allows pipelines to be manually (i can seperate this out if we must)
second commit adds in more robust and verbose logging so we could track down why the API calls were failing

then we did more testing and found that the API call was failing because we were doing an `apply` and it was cuasing the annotaitons to grow too big. in this case we really only need to do a patch so switching over to that.

the more detailed error:
```
{
    "timestamp": 1743546112871,
    "elapsed_time": 0.6327354907989502,
    "success": false,
    "status": 1,
    "verb": "apply",
    "cmd": [
        "oc",
        "apply",
        "--namespace=openshift-storage",
        "-f",
        "-"
    ],
    "out": "",
    "err": "Warning: resource installplans/install-kwgwp is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.\nThe InstallPlan \"install-kwgwp\" is invalid: metadata.annotations: Too long: must have at most 262144 bytes\n",
    "in": "**REDACTED**",
    "references": {
        ".stack": [
            "  File \"/scripts/installplan-incremental-approver.py\", line 80, in <module>\n    target_installplan\n",
            "  File \"/scripts/..2025_04_01_22_21_44.1111213760/installplan_utils.py\", line 132, in approve_installplan\n    ) = installplan.modify_and_apply(installplan_approve_modify_and_apply, 4)\n",
            "  File \"/tmp/venv/lib64/python3.6/site-packages/openshift_client/apiobject.py\", line 501, in modify_and_apply\n    last_attempt=(attempt == 0))\n",
            "  File \"/tmp/venv/lib64/python3.6/site-packages/openshift_client/action.py\", line 384, in oc_action\n    references['.stack'] = traceback.format_stack()\n"
        ]
    },
    "timeout": false,
    "last_attempt": true,
    "internal": false
}
```

#### How do we test this?
- [x] existing tests pass
- [x] live UAT test where we were hitting the unhandled path
- [x] new tests - cant think of a way to craft a test that hits the error case :(
   * ideally we would add a test with an operator that causes this issue, but the only reproducable one we have right now is ODF and that isn't reasonable to try and do in a test environment. the likely reason this is happenign with ODF and we havn't seen it with other operators is because ODF operator has so many other operator dependencies which cause the install plan to become rather large.

cc: @redhat-cop/day-in-the-life
