### PR TITLE
Create OLM v1 chart

### DIFF
--- a/.github/actions/setup-kind-cluster-for-helm-chart-testing/action.yaml
+++ b/.github/actions/setup-kind-cluster-for-helm-chart-testing/action.yaml
@@ -25,6 +25,12 @@ inputs:
     required: true
     default: 'v0.41.0'
 
+  # renovate: datasource=github-releases depName=operator-framework/operator-controller
+  olmv1-version:
+    description: olmv1 version to install
+    required: true
+    default: 'latest'
+
   local-registry-enabled:
     description: whether to enable local authenticated registry
     required: true
@@ -79,6 +85,14 @@ runs:
       curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh -o install.sh
       chmod +x install.sh
         ./install.sh ${OLM_VERSION}
+
+  # for helm charts we are testing that require installing OLMv1 Cluster Extensions
+  - name: Setup kind cluster - Install OLMv1 🧰
+    env:
+      OLMV1_VERSION: ${{ inputs.olmv1-version }}
+    shell: bash
+    run: |
+      curl -L -s https://github.com/operator-framework/operator-controller/releases/${OLMV1_VERSION}/download/install.sh | bash -s
 
   # for helm charts we are testing that require ingress
   - name: Setup kind cluster - Install ingress controller 🧰

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For more info on each chart checkout these!
 * [jenkins](/charts/jenkins)
 * [kopf](/charts/kopf)
 * [network-policy](/charts/network-policy)
+* [olmv1](/charts/olmv1)
 * [openshift-logforwarding-splunk](/charts/openshift-logforwarding-splunk)
 * [operatorhub](/charts/operatorhub)
 * [operators-installer](/charts/operators-installer)
@@ -74,7 +75,6 @@ For more info on each chart checkout these!
 * [stackrox](/charts/stackrox)
 * [static-site](/charts/static-site)
 * [tekton-demo](/charts/tekton-demo)
-* [operators-installer](/charts/operators-installer)
 
 ## [pre-commit](.pre-commit-config.yaml)
 

--- a/_test/conftest.sh
+++ b/_test/conftest.sh
@@ -250,3 +250,14 @@ setup_file() {
   print_info "${status}" "${output}" "${cmd}" "${tmp}"
   [ "$status" -eq 0 ]
 }
+
+@test "charts/olmv1" {
+  tmp=$(helm_template "charts/olmv1" "-f charts/olmv1/ci/ci-values.yaml")
+
+  namespaces=$(get_rego_namespaces "ocp\.deprecated\.*")
+  cmd="conftest test ${tmp} --output tap ${namespaces}"
+  run ${cmd}
+
+  print_info "${status}" "${output}" "${cmd}" "${tmp}"
+  [ "$status" -eq 0 ]
+}

--- a/charts/olmv1/.helmignore
+++ b/charts/olmv1/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/olmv1/Chart.yaml
+++ b/charts/olmv1/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: olmv1
+description: Installs operators or cluster extensions in a declarative, GitOps friendly way using olmv1
+type: application
+version: 1.0.0
+
+home: https://github.com/redhat-cop/helm-charts
+icon: https://raw.githubusercontent.com/operator-framework/olm-docs/ea9cd734aa7a6bf2d24f273322ed9aec3ffcb02a/content/en/images/logo-sm.svg
+
+keywords:
+- olm
+- olmv1
+- operators
+- extensions
+
+maintainers:
+- name: marpears

--- a/charts/olmv1/README.md
+++ b/charts/olmv1/README.md
@@ -1,0 +1,77 @@
+# olmv1
+
+## Introduction
+
+This chart will install operators or cluster extensions in a declarative, GitOps friendly way using OLM v1.
+
+Please refer to the official OpenShift documentation for more information about how OLM v1 works: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/extensions/index#extensions-overview
+
+## Values
+
+Here are the values used by this chart
+
+| Value                     | Type    | Required  | Description                                                                                                 |
+| -----------------------   | ------- | ----------| ----------------------------------------------------------------------------------------------------------- |
+| name                      | string  | yes       | Name for the `ClusterExtension`                                                                               |
+| namespace                 | string  | yes       | Namespace to create resources in                                                                            |
+| upgradeConstraintPolicy   | string  | No        | Populates `clusterextension.spec.source.catalog.upgradeConstraintPolicy`                                    |
+| version                   | string  | no        | Populates `clusterextension.spec.source.catalog.version`                                                    |
+| channels                  | list    | no        | Populates `clusterextension.spec.source.catalog.channels`                                                   |
+| catalogSelector           | map     | no        | Populates `clusterextension.spec.source.catalog.selector`                                                   |
+| upgradeConstraintPolicy   | string  | no        | Populates `clusterextension.spec.source.catalog.upgradeConstraintPolicy`                                    |
+| packageName               | string  | no        | Populates `clusterextension.spec.source.catalog.packageName`                                                |
+| clusterRole               | string  | yes *     | Specify a cluster role to assign to the ServiceAccount used to install the operator                         |
+| rbac                      | map     | yes *     | Specify cluster and/or namespace rbac rules to assign to the ServiceAccount used to install the operator    |
+
+\* One of `clusterRole` or `rbac` is required.
+
+## Examples
+
+### Install cert-manager using selective RBAC rules
+
+```
+- name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+  upgradeConstraintPolicy: CatalogProvided
+  packageName: openshift-cert-manager-operator
+  version: 1.16.1
+  channels:
+  - stable-v1.16
+  rbac:
+    cluster:
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources: ["customresourcedefinitions"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources: ["clusterrolebindings"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["olm.operatorframework.io"]
+      resources: ["clusterextensions/finalizers"]
+      verbs: ["get", "update", "patch"]
+    namespace:
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "watch", "list"]
+    - apiGroups: [""]
+      resources: ["serviceaccounts"]
+      verbs: ["get", "list", "watch", "create"]
+    - apiGroups: [""]
+      resources: ["services"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["apps"]
+      resources: ["deployments"]
+      verbs: ["get", "list", "watch"]
+```
+
+### Install cert-manager using the cluster-admin role
+
+```
+- name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+  upgradeConstraintPolicy: CatalogProvided
+  packageName: openshift-cert-manager-operator
+  version: 1.16.1
+  channels:
+  - stable-v1.16
+  clusterRole: cluster-admin
+```

--- a/charts/olmv1/ci/ci-values.yaml
+++ b/charts/olmv1/ci/ci-values.yaml
@@ -1,0 +1,17 @@
+extensions:
+- name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+  upgradeConstraintPolicy: CatalogProvided
+  packageName: openshift-cert-manager-operator
+  version: 1.16.1
+  channels:
+  - stable-v1.16
+  rbac:
+    cluster:
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources: ["customresourcedefinitions"]
+      verbs: ["get", "list", "watch"]
+    namespace:
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "watch", "list"]

--- a/charts/olmv1/templates/clusterextension.yaml
+++ b/charts/olmv1/templates/clusterextension.yaml
@@ -1,0 +1,32 @@
+{{- range .Values.extensions }}
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: {{ .name }}
+spec:
+  namespace: {{ .namespace }}
+  serviceAccount:
+    name: {{ .packageName }}-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: {{ .packageName }}
+{{- if .catalogSelector }}
+      selector:
+{{- toYaml .catalogSelector | nindent 8 }}
+{{- end }}
+{{- if .upgradeConstraintPolicy }}
+      upgradeConstraintPolicy: {{ .upgradeConstraintPolicy }}
+{{- end }}
+{{- if .channels }}
+      channels:
+{{- range .channels }}
+        - {{ . }}
+{{- end }}
+{{- end }}
+{{- if .version }}
+      version: {{ .version | toString }}
+{{- end }}
+
+{{- end }}

--- a/charts/olmv1/templates/clusterrole.yaml
+++ b/charts/olmv1/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- range .Values.extensions }}
+{{- if and .rbac .rbac.cluster }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .packageName }}-installer
+rules:
+{{ toYaml .rbac.cluster }}
+
+{{- end }}
+{{- end }}

--- a/charts/olmv1/templates/clusterrolebinding.yaml
+++ b/charts/olmv1/templates/clusterrolebinding.yaml
@@ -1,0 +1,34 @@
+{{- range .Values.extensions }}
+{{- if and .rbac .rbac.cluster }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .packageName }}-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .packageName }}-installer
+subjects:
+- kind: ServiceAccount
+  name: {{ .packageName }}-installer
+  namespace: {{ .namespace }}
+
+{{- end }}
+{{- if .clusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .packageName }}-{{ .clusterRole }}-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .clusterRole }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .packageName }}-installer
+  namespace: {{ .namespace }}
+{{- end }}
+
+{{- end }}

--- a/charts/olmv1/templates/namespace.yaml
+++ b/charts/olmv1/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extensions }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .namespace }}
+
+{{- end }}

--- a/charts/olmv1/templates/required.yaml
+++ b/charts/olmv1/templates/required.yaml
@@ -1,0 +1,13 @@
+{{- $_ := required ".Values.extensions is required" .Values.extensions }}
+{{- range .Values.extensions }}
+{{- $_ := required "name is required" .name }}
+{{- $_ := required "namespace is required" .namespace }}
+{{- $_ := required "packageName is required" .packageName }}
+
+{{- $clusterRole := .clusterRole }}
+{{- $rbacRules := .rbac }}
+
+{{- if not (or $clusterRole $rbacRules) }}
+{{- $_ := required "Either a cluster role or rbac rules must be defined" nil }}
+{{- end }}
+{{- end }}

--- a/charts/olmv1/templates/role.yaml
+++ b/charts/olmv1/templates/role.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.extensions }}
+{{- if and .rbac .rbac.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .packageName }}-installer
+  namespace: {{ .namespace }}
+rules:
+{{ toYaml .rbac.namespace }}
+{{- end }}
+
+{{- end }}

--- a/charts/olmv1/templates/rolebinding.yaml
+++ b/charts/olmv1/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- range .Values.extensions }}
+{{- if and .rbac .rbac.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .packageName }}-installer
+  namespace: {{ .namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .packageName }}-installer
+subjects:
+- kind: ServiceAccount
+  name: {{ .packageName }}-installer
+{{- end }}
+
+{{- end }}

--- a/charts/olmv1/templates/serviceaccount.yaml
+++ b/charts/olmv1/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- range .Values.extensions }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .packageName }}-installer
+  namespace: {{ .namespace }}
+
+{{- end }}

--- a/charts/olmv1/values.yaml
+++ b/charts/olmv1/values.yaml
@@ -1,0 +1,37 @@
+extensions:
+
+# Define operator name and namespace (required)
+#  - name: openshift-cert-manager-operator
+#    namespace: openshift-cert-manager-operator
+
+# Define the ClusterCatalog selector (optional)
+#    catalogSelector:
+#      matchLabels:
+#        olm.operatorframework.io/openshift-certified-operators
+#      matchExpressions:
+#        - { key: mykey, operator: In, values: [myvalue] }
+#        - { key: mykey1, operator: NotIn, values: [myvalue1] }
+
+# Define the upgradeConstraintPolicy (optional)
+#    upgradeConstraintPolicy:
+
+# Define the package name (required)
+#    packageName:
+
+# Define the version and list of channels (optional)
+#    version:
+#    channels:
+#    -
+
+# Define either a cluster role or custom cluster and namespace scoped rbac
+# rules to bind to the service account (required)
+#    clusterRole: cluster-admin
+#    rbac:
+#      cluster:
+#      - apiGroups: ["apiextensions.k8s.io"]
+#        resources: ["customresourcedefinitions"]
+#        verbs: ["get", "list", "watch"]
+#      namespace:
+#      - apiGroups: [""]
+#        resources: ["pods"]
+#        verbs: ["get", "watch", "list"]


### PR DESCRIPTION
#### What is this PR About?
OLM v1 is a declarative and GitOps friendly way of installing operators or extensions, and has been [GA since OpenShift 4.18](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/extensions/index#extensions-overview).

In this PR, a new helm chart named olmv1 has been created which configures ClusterExtension CRs and the supporting manifests needed to provide the necessary rbac for installation to complete.

Having a chart for OLM v1 will hopefully help boost the testing and adoption effort needed to ensure compatibility of all operators.

#### How do we test this?
The chart can be linted using this command:
`helm lint -f charts/olmv1/_test/values.yaml charts/olmv1`

The conftest script used by the GitHub action has been updated to include this new chart and uses the test values file.

cc: @redhat-cop/day-in-the-life