### PR TITLE
Add extra environment variable support for approver and verifier Jobs 

### DIFF
--- a/charts/operators-installer/Chart.yaml
+++ b/charts/operators-installer/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.3
+version: 3.5.0
 
 home: https://github.com/redhat-cop/helm-charts
 

--- a/charts/operators-installer/README.md
+++ b/charts/operators-installer/README.md
@@ -45,7 +45,8 @@ For all of the Subscription parameters see
 | installPlanApproverAndVerifyJobsImage        | `registry.redhat.io/openshift4/ose-cli:v4.10` | Yes | Image to use for the InstallPlan Approver and Verify Jobs
 | installPlanApproverAndVerifyJobsImagePullSecret   | `''` | No | Name of existing secret for pulling `installPlanApproverAndVerifyJobsImage` from a private registry
 | approveManualInstallPlanViaHook              | `true`        | No        | `true` to create (and clean up) manual InstallPlan approval resources as part of post-install,post-upgrade helm hook<br>`false` to create  manual InstallPlan approval resources as part of normal install<br><br>The hook method is nice to not have lingering resources needed for the manual InstallPlan approval but has the downside that no CustomResources using CustomResourceDefinitions installed by the operator can be used in the same chart because the operator InstallPlan wont be approved, and therefor the operator wont be installed, until the post-install,post-upgrade phase which means you will never get to that phase because your CustomResources wont be able to apply because the Operator isn't installed.<br><br>This is is ultimately a trade off between cleaning up these resources or being able to install and configure the operator in the same helm chart that has a dependency on this helm chart.
-| installPlanApproverAndVerifyJobsTolerations. | []            | No.       | Tolerations to apply to the approver and verify Jobs. See Kubernetes documentation on tolerations.
+| installPlanApproverAndVerifyJobsTolerations  | `[]`          | No        | Tolerations to apply to the approver and verify Jobs. See Kubernetes documentation on tolerations.
+| installPlanApproverAndVerifyJobsExtraEnv     | `[]`          | No        | Extra environment variables to add to the InstallPlan Approver and Verify Job containers. Useful for injecting proxy configuration. Each entry should have `name` and `value` (or `valueFrom`) fields.
 | installRequiredPythonLibraries               | `true`        | No        | If `true`, install the required Python libraries (openshift-client, semver==2.13.0) dynamically from the given `pythonIndexURL` and `pythonExtraIndexURL` into the `installPlanApproverAndVerifyJobsImage` at run time
 | pythonIndexURL                               | https://pypi.org/simple/ | No | If `installRequiredPythonLibraries` is `true` then use this python index to pull required libraries
 | pythonExtraIndexURL                          | https://pypi.org/simple/ | No | If `installRequiredPythonLibraries` is `true` then use this python extra index to pull required library dependencies
@@ -71,6 +72,21 @@ Build a custom container image with:
 Suggestion is to build such an image on top of the latest `registry.redhat.io/openshift4/ose-cli` image
 
 Then provide that custom image to `installPlanApproverAndVerifyJobsImage` and set `installRequiredPythonLibraries` to false.
+
+#### HTTP Proxy
+If your environment requires an HTTP proxy for internet access, use `installPlanApproverAndVerifyJobsExtraEnv` to inject proxy environment variables into the approver and verifier Job containers:
+
+```yaml
+installPlanApproverAndVerifyJobsExtraEnv:
+  - name: HTTP_PROXY
+    value: "http://proxy.example.com:3128"
+  - name: HTTPS_PROXY
+    value: "http://proxy.example.com:3128"
+  - name: NO_PROXY
+    value: ".cluster.local,10.0.0.0/8"
+```
+
+This is needed when `installRequiredPythonLibraries` is `true` (the default), as `pip install` requires network access to download Python packages from `pythonIndexURL`.
 
 ### Can not install / upgrade different operators in same namespace independently
 As documented in [How can Operators be updated independently from each other?](https://access.redhat.com/solutions/6389681) when more then one operator install or update is pending in the same namespace the Operator Lifecycle Manager (OLM) will combine those installs/updates into a single InstallPlan and there is no way to separate them. Therefor if you use this helm chart in namespace ZZZ to install operator A at v1.0 and it has a pending update to v1.1 and then update the configuration to also install operator B at v42.0 in namespace ZZZ the ZZZ v42.0 InstallPlan and the A v1.1 InstallPlan will get merged (by OLM) and this helm chart will then approve that InstallPlan as it will match on the ZZZ v42.0 pending install, which will incidentally install the A v1.1 update.

--- a/charts/operators-installer/ci/test-install-with-extra-env-values.yaml
+++ b/charts/operators-installer/ci/test-install-with-extra-env-values.yaml
@@ -1,0 +1,27 @@
+approveManualInstallPlanViaHook: true
+
+installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.15
+
+installPlanApproverAndVerifyJobsExtraEnv:
+- name: HTTP_PROXY
+  value: "http://proxy.example.com:3128"
+- name: HTTPS_PROXY
+  value: "http://proxy.example.com:3128"
+- name: NO_PROXY
+  value: ".cluster.local,10.0.0.0/8"
+
+operatorGroups:
+- name: argocd-operator-2
+  createNamespace: true
+  targetOwnNamespace: true
+  otherTargetNamespaces:
+
+operators:
+- name: argocd-operator
+  channel: alpha
+  csv: argocd-operator.v0.6.0
+  installPlanApproval: Manual
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  namespace: argocd-operator-2
+  installPlanVerifierActiveDeadlineSeconds: 1200

--- a/charts/operators-installer/ci/test-install-with-extra-env-values.yaml
+++ b/charts/operators-installer/ci/test-install-with-extra-env-values.yaml
@@ -2,13 +2,12 @@ approveManualInstallPlanViaHook: true
 
 installPlanApproverAndVerifyJobsImage: quay.io/openshift/origin-cli:4.15
 
+# Test extraEnv injection with a harmless env var.
+# Proxy-specific values (HTTP_PROXY, etc.) can't be tested here
+# because the kind cluster has no real proxy.
 installPlanApproverAndVerifyJobsExtraEnv:
-- name: HTTP_PROXY
-  value: "http://proxy.example.com:3128"
-- name: HTTPS_PROXY
-  value: "http://proxy.example.com:3128"
-- name: NO_PROXY
-  value: ".cluster.local,10.0.0.0/8"
+- name: OPERATORS_INSTALLER_TEST_ENV
+  value: "extra-env-works"
 
 operatorGroups:
 - name: argocd-operator-2

--- a/charts/operators-installer/templates/Job_installplan-approver.yaml
+++ b/charts/operators-installer/templates/Job_installplan-approver.yaml
@@ -61,6 +61,9 @@ spec:
         - name: INCREMENTAL_INSTALL_DELAY_INCREMENT
           value: "{{ .automaticIntermediateManualUpgradesIncrementalInstallDelayIncrement | default 5 }}"
         {{- end }}
+        {{- if $.Values.installPlanApproverAndVerifyJobsExtraEnv }}
+        {{- $.Values.installPlanApproverAndVerifyJobsExtraEnv | toYaml | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: operators-installer-approver-scripts
           mountPath: /scripts

--- a/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
+++ b/charts/operators-installer/templates/Job_installplan-complete-verifier.yaml
@@ -50,6 +50,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if $.Values.installPlanApproverAndVerifyJobsExtraEnv }}
+        {{- $.Values.installPlanApproverAndVerifyJobsExtraEnv | toYaml | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: operators-installer-approver-scripts
           mountPath: /scripts

--- a/charts/operators-installer/values.yaml
+++ b/charts/operators-installer/values.yaml
@@ -17,6 +17,20 @@ installPlanApproverAndVerifyJobsImage: registry.redhat.io/openshift4/ose-cli:v4.
 # Accepts a single string which is the name of an existing secret. (This chart does not create or manage the secret.)
 installPlanApproverAndVerifyJobsImagePullSecret:
 
+# Extra environment variables to add to the InstallPlan Approver and Verify Job containers.
+# Useful for injecting proxy configuration (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) in environments
+# where internet access requires an HTTP proxy.
+#
+# Example:
+#   installPlanApproverAndVerifyJobsExtraEnv:
+#     - name: HTTP_PROXY
+#       value: "http://proxy.example.com:3128"
+#     - name: HTTPS_PROXY
+#       value: "http://proxy.example.com:3128"
+#     - name: NO_PROXY
+#       value: ".cluster.local,10.0.0.0/8"
+installPlanApproverAndVerifyJobsExtraEnv: []
+
 # If `true`, install the required Python libraries (openshift-client, semver==2.13.0) dynamically
 # from the given `pythonIndexURL` and `pythonExtraIndexURL` into the `installPlanApproverAndVerifyJobsImage` at run time
 #


### PR DESCRIPTION
#### What is this PR About?

Add `installPlanApproverAndVerifyJobsExtraEnv` value to inject arbitrary environment variables into InstallPlan approver and verifier Job containers.

This is needed for environments behind an HTTP proxy where `pip install` (used when `installRequiredPythonLibraries: true`) cannot reach pypi.org without HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars.

#### How do we test this?
                                                                                                                                                                            
helm template test charts/operators-installer \                                                                                                                           
    --set 'operators[0].name=test-operator' \                                                                                                                               
    --set 'operators[0].channel=stable' \                                                                                                                                   
    --set 'operators[0].installPlanApproval=Manual' \                                                                                                                       
    --set 'operators[0].csv=test-operator.v1.0.0' \                                                                                                                         
    --set 'operators[0].source=community-operators' \                                                                                                                       
    --set 'operators[0].sourceNamespace=openshift-marketplace' \                                                                                                            
    --set 'installPlanApproverAndVerifyJobsExtraEnv[0].name=HTTP_PROXY' \                                                                                                   
    --set 'installPlanApproverAndVerifyJobsExtraEnv[0].value=http://proxy:3128' \                                                                                           
    --set 'installPlanApproverAndVerifyJobsExtraEnv[1].name=HTTPS_PROXY' \                                                                                                  
    --set 'installPlanApproverAndVerifyJobsExtraEnv[1].value=http://proxy:3128'                                                                                             
                                                                                                                                                                            
Verify that both the approver and verifier Job specs contain HTTP_PROXY and HTTPS_PROXY env vars. Also verify that omitting installPlanApproverAndVerifyJobsExtraEnv      
  produces identical output to the unmodified chart. 

cc: @redhat-cop/day-in-the-life

#### Blocked By:
* https://github.com/redhat-cop/helm-charts/pull/663
* https://github.com/redhat-cop/helm-charts/pull/664

#### found but not blocking:
* https://github.com/redhat-cop/helm-charts/pull/662
