### PR TITLE
ci - update actions/checkout to v6.0.2 due to future deprecation of v4

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Conftest
         uses: redhat-cop/github-actions/confbatstest@561af5e610560aef3210ca7a08fe73b2add97648 # v4.5

--- a/.github/workflows/install-integration-tests-operators-installer.yaml
+++ b/.github/workflows/install-integration-tests-operators-installer.yaml
@@ -26,7 +26,7 @@ jobs:
       TEST_NAMESPACE: 'operators-installer-integration-test'
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
       LOCAL_REGISTRY_IMAGES: "quay.io/openshift/origin-cli:4.15" # space separated
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/install-unit-test.yaml
+++ b/.github/workflows/install-unit-test.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/precommit-validate.yml
+++ b/.github/workflows/precommit-validate.yml
@@ -17,7 +17,7 @@ jobs:
     name: pre-commit
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2.2.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2.2.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
#### What is this PR About?
update actions/checkout to v6.0.2 due to future deprecation of v4

#### How do we test this?
it is an update to the tests. so its self testing.

cc: @redhat-cop/day-in-the-life
